### PR TITLE
fix(desktop): use theme-aware bg-card for iframe containers

### DIFF
--- a/apps/desktop/src/components/blocks/preview-carousel.tsx
+++ b/apps/desktop/src/components/blocks/preview-carousel.tsx
@@ -209,7 +209,7 @@ export function PreviewCarousel({
                 // Desktop frame - 1500:865 native, scaled to fit
                 <div
                   className={cn(
-                    "relative bg-white rounded-lg overflow-hidden",
+                    "relative bg-card rounded-lg overflow-hidden",
                     "shadow-[0_0_0_1px_rgba(255,255,255,0.1),0_25px_50px_-12px_rgba(0,0,0,0.8)]"
                   )}
                   style={{

--- a/apps/desktop/src/components/canvas/screen-node.tsx
+++ b/apps/desktop/src/components/canvas/screen-node.tsx
@@ -108,7 +108,7 @@ function ScreenNodeComponent({ id, data, selected }: NodeProps) {
               </IPhoneFrame>
             ) : (
               <div
-                className="bg-white rounded-lg overflow-hidden shadow-xl ring-1 ring-border relative"
+                className="bg-card rounded-lg overflow-hidden shadow-xl ring-1 ring-border relative"
                 style={{ width: WEB_WIDTH, height: WEB_HEIGHT }}
               >
                 {/* Overlay to capture mouse events */}


### PR DESCRIPTION
## Summary

Fix iframe containers appearing white in dark mode by using theme-aware `bg-card` class instead of hardcoded `bg-white`.

## Changes

- **screen-node.tsx**: Replace `bg-white` with `bg-card` for web preview frame on canvas
- **preview-carousel.tsx**: Replace `bg-white` with `bg-card` for desktop frame in carousel dialog

## Before/After

| Theme | Before | After |
|-------|--------|-------|
| Light | White background | Near-white with warm tint (`oklch 0.995`) |
| Dark | White background (jarring) | Dark gray-blue (`oklch 0.18`) |

## Notes

- `web-preview.tsx` already used `bg-background` correctly
- `bg-card` was chosen over `bg-background` as it provides a subtle elevated surface that works well for preview containers