### PR TITLE
Add auto-install for dependencies and misc improvements

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -118,6 +118,7 @@ pub fn run() {
             // OpenCode commands
             opencode::check_opencode_installation,
             opencode::check_bun_installation,
+            opencode::install_dependencies,
             opencode::get_opencode_port,
             opencode::start_opencode_server,
             opencode::stop_opencode_server,

--- a/apps/desktop/src/routes/studio.$sessionId.tsx
+++ b/apps/desktop/src/routes/studio.$sessionId.tsx
@@ -34,7 +34,8 @@ import {
 } from "@/components/ui/alert-dialog";
 import { ChatView } from "@/components/blocks/chat-view";
 import { DesignCanvas } from "@/components/canvas";
-import { PanelLeftClose, PanelLeftOpen, Copy, ChevronDown, GitFork, Pencil, Palette, Play, Download } from "lucide-react";
+import { PanelLeftClose, PanelLeftOpen, Copy, ChevronDown, GitFork, Pencil, Palette } from "lucide-react";
+import { Play, DownloadSimple } from "@phosphor-icons/react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -342,7 +343,7 @@ function StudioPage() {
             onClick={() => setPreviewOpen(true)}
             disabled={designs.length === 0}
           >
-            <Play className="size-3.5" />
+            <Play className="size-3.5" weight="fill" />
             Preview
             {selectedScreenIds.size > 0 && (
               <span className="text-muted-foreground">({selectedScreenIds.size})</span>
@@ -364,7 +365,7 @@ function StudioPage() {
             }}
             disabled={designs.length === 0}
           >
-            <Download className="size-3.5" />
+            <DownloadSimple className="size-3.5" weight="bold" />
             Export
             {selectedScreenIds.size > 0 && (
               <span className="text-muted-foreground">({selectedScreenIds.size})</span>

--- a/apps/web/src/app/api/trial/route.ts
+++ b/apps/web/src/app/api/trial/route.ts
@@ -73,7 +73,7 @@ export async function POST(request: NextRequest) {
     await polar.customers.create({
       organizationId: ORG_ID,
       externalId: device_id,
-      email: `device-${device_id.substring(0, 8)}@trial.dilag.app`,
+      email: `trial-${device_id.substring(0, 8)}@dilag.noelrohi.com`,
       name: `Trial Device ${device_id.substring(0, 8)}`,
       metadata: {
         trial_start_utc: trialStartUtc,


### PR DESCRIPTION
## Summary

Streamline the setup experience by auto-installing dependencies and include minor UI/config fixes.

## Changes

- **feat(desktop):** Add `install_dependencies` Tauri command that installs Bun and OpenCode via their official install scripts
- **refactor(desktop):** Simplify setup wizard UI with minimal design and one-click install flow
- **style(desktop):** Use Phosphor icons for Preview/Export buttons
- **fix(web):** Update trial email domain to `@dilag.noelrohi.com`

## Testing

1. Launch app without Bun/OpenCode installed
2. Click "Install" in the setup wizard
3. Verify both dependencies install successfully