### PR TITLE
feat: activity indicators, mobile sidebar, and session metadata improvements

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "dilag"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -41,7 +41,7 @@ pub fn run() {
                 WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::App("index.html".into()))
                     .title("Dilag")
                     .inner_size(1000.0, 700.0)
-                    .min_inner_size(600.0, 400.0)
+                    .min_inner_size(768.0, 600.0)
                     .maximized(true)
                     .title_bar_style(TitleBarStyle::Transparent)
                     .hidden_title(true)

--- a/apps/desktop/src/components/ui/sidebar.tsx
+++ b/apps/desktop/src/components/ui/sidebar.tsx
@@ -304,7 +304,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
   )
 }
 
-function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+function SidebarInset({ className, children, ...props }: React.ComponentProps<"main">) {
   return (
     <main
       data-slot="sidebar-inset"
@@ -314,7 +314,13 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
         className
       )}
       {...props}
-    />
+    >
+      <SidebarTrigger
+        className="fixed left-3 top-12 z-40 rounded-md border bg-background/80 shadow-sm backdrop-blur md:hidden"
+        aria-label="Open sidebar"
+      />
+      {children}
+    </main>
   )
 }
 

--- a/apps/desktop/src/context/session-store.tsx
+++ b/apps/desktop/src/context/session-store.tsx
@@ -605,6 +605,17 @@ export const useSessionStore = create<SessionState>()(
               text: "text" in sdkPart ? sdkPart.text : undefined,
               tool: "tool" in sdkPart ? sdkPart.tool : undefined,
               state: "state" in sdkPart ? sdkPart.state : undefined,
+              mime: "mime" in sdkPart ? sdkPart.mime : undefined,
+              url: "url" in sdkPart ? sdkPart.url : undefined,
+              filename: "filename" in sdkPart ? sdkPart.filename : undefined,
+              provider:
+                "provider" in sdkPart && typeof (sdkPart as { provider?: unknown }).provider === "string"
+                  ? (sdkPart as { provider: string }).provider
+                  : undefined,
+              model:
+                "model" in sdkPart && typeof (sdkPart as { model?: unknown }).model === "string"
+                  ? (sdkPart as { model: string }).model
+                  : undefined,
             };
             updatePart(sdkPart.messageID, part);
           }

--- a/apps/desktop/src/hooks/use-sessions.ts
+++ b/apps/desktop/src/hooks/use-sessions.ts
@@ -40,6 +40,15 @@ function convertPart(part: Part, messageID: string, sessionID: string): MessageP
     mime: "mime" in part ? part.mime : undefined,
     url: "url" in part ? part.url : undefined,
     filename: "filename" in part ? part.filename : undefined,
+    // Step part fields
+    provider:
+      "provider" in part && typeof (part as { provider?: unknown }).provider === "string"
+        ? (part as { provider: string }).provider
+        : undefined,
+    model:
+      "model" in part && typeof (part as { model?: unknown }).model === "string"
+        ? (part as { model: string }).model
+        : undefined,
   };
 }
 

--- a/apps/web/src/app/api/trial/route.ts
+++ b/apps/web/src/app/api/trial/route.ts
@@ -3,15 +3,14 @@ import { polar, TRIAL_DAYS } from "@/lib/polar";
 import type {
   TrialRegisterRequest,
   TrialRegisterResponse,
-  TrialCheckRequest,
   TrialCheckResponse,
 } from "@dilag/shared";
 
 /**
  * POST /api/trial - Register or check a device trial
- * 
+ *
  * Body: { device_id: string }
- * 
+ *
  * Flow:
  * 1. Check if customer with external_id=device_id exists
  * 2. If exists, return existing trial info
@@ -41,7 +40,7 @@ export async function POST(request: NextRequest) {
     if (existingCustomer) {
       // Customer exists - check trial status
       const trialStartUtc = existingCustomer.metadata?.trial_start_utc as number | undefined;
-      
+
       if (!trialStartUtc) {
         // Customer exists but no trial - shouldn't happen, but handle it
         return NextResponse.json<TrialRegisterResponse>({
@@ -58,8 +57,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json<TrialRegisterResponse>({
         allowed: !expired,
         trial_start_utc: trialStartUtc,
-        message: expired 
-          ? "Trial has expired" 
+        message: expired
+          ? "Trial has expired"
           : `Trial active, ${daysRemaining} days remaining`,
       });
     }


### PR DESCRIPTION
## Summary

Adds real-time activity status indicators to the chat interface, improves mobile responsiveness with a sidebar trigger, and extends session metadata to support media and step tracking.

## Changes

- **chore(desktop)**: Bump version to 0.3.8 and increase minimum window size to 768x600
- **feat(chat)**: Add activity status indicators showing tool activity (Running command, Searching project, Waiting for permission, etc.) with randomized busy fallbacks
- **feat(ui)**: Add fixed mobile sidebar trigger for responsive layout; extend message parts with media fields (mime, url, filename) and step fields (provider, model)
- **test**: Update setup wizard and session hook tests for new UI copy and mocks
- **style(api)**: Clean up trial route formatting

## Testing

1. Run desktop app and observe activity indicators during AI responses
2. Resize window to mobile width and verify sidebar trigger appears
3. Run tests: `bun test` in `apps/desktop`