### PR TITLE
feat(desktop): connect pi provider models

### DIFF
--- a/apps/desktop/electron/ipc/host.ts
+++ b/apps/desktop/electron/ipc/host.ts
@@ -17,6 +17,7 @@ import {
   isAgentRuntimeRunning,
   listAgentProviders,
   listAgentQuestions,
+  loginAgentOAuthProvider,
   navigateAgentTree,
   promptAgentSession,
   rejectAgentQuestion,
@@ -75,6 +76,9 @@ export function registerHostHandlers(getWindow: () => BrowserWindow | null) {
   ipcMain.handle(CHANNELS.agent.setApiKey, (_event, args: { providerID: string; apiKey: string }) =>
     setAgentApiKey(args),
   )
+  ipcMain.handle(CHANNELS.agent.loginOAuthProvider, (_event, args: { providerID: string }) =>
+    loginAgentOAuthProvider(args, (url) => shell.openExternal(url)),
+  )
   ipcMain.handle(CHANNELS.agent.createSession, (_event, args: { directory: string }) =>
     createAgentSessionForDirectory(args),
   )
@@ -96,6 +100,7 @@ export function registerHostHandlers(getWindow: () => BrowserWindow | null) {
         text: string
         images?: Array<{ type: "image"; data: string; mimeType: string }>
         model?: { providerID: string; modelID: string } | null
+        thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh"
       },
     ) => promptAgentSession(args),
   )

--- a/apps/desktop/electron/ipc/pi.ts
+++ b/apps/desktop/electron/ipc/pi.ts
@@ -15,6 +15,7 @@ import type {
   AgentQuestionRequest,
   AgentRuntimeInfo,
   AgentSessionInfo,
+  AgentThinkingLevel,
   AgentTreeNode as BridgeAgentTreeNode,
 } from "@dilag/desktop-bridge"
 import fsp from "node:fs/promises"
@@ -43,6 +44,8 @@ type PiMessage = {
   errorMessage?: string
   stopReason?: string
 }
+
+type RequestedAgentModel = { providerID: string; modelID: string }
 
 type RuntimeSession = {
   id: string
@@ -74,6 +77,7 @@ type PiSessionTreeNode = {
 
 const sessions = new Map<string, RuntimeSession>()
 const pendingQuestions = new Map<string, PendingQuestion>()
+const OAUTH_PROVIDER_IDS = new Set(["openai-codex", "github-copilot"])
 
 let eventSender: EventSender | undefined
 let piModulePromise: Promise<typeof import("@earendil-works/pi-coding-agent")> | undefined
@@ -132,6 +136,7 @@ export async function getAgentProviderData(): Promise<AgentProviderData> {
     cost: model.cost,
     contextWindow: model.contextWindow,
     maxTokens: model.maxTokens,
+    variants: getThinkingLevelVariants(model),
   }))
   const connectedProviders = [...new Set(models.map((model) => model.providerID))]
   const first = models[0]
@@ -140,6 +145,21 @@ export async function getAgentProviderData(): Promise<AgentProviderData> {
     connectedProviders,
     defaultModel: first ? { providerID: first.providerID, modelID: first.id } : null,
   }
+}
+
+function getThinkingLevelVariants(model: { reasoning?: boolean; thinkingLevelMap?: Partial<Record<AgentThinkingLevel, string | null>> }) {
+  if (!model.reasoning) return undefined
+  const levels: AgentThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh"]
+  const available = levels.filter((level) => {
+    const mapped = model.thinkingLevelMap?.[level]
+    if (mapped === null) return false
+    if (level === "xhigh") return mapped !== undefined
+    return true
+  })
+  return Object.fromEntries(available.map((level) => [level, {}])) as Record<
+    AgentThinkingLevel,
+    Record<string, unknown>
+  >
 }
 
 export async function listAgentProviders(): Promise<AgentProvider[]> {
@@ -155,6 +175,7 @@ export async function listAgentProviders(): Promise<AgentProvider[]> {
       name: humanizeProviderName(id),
       connected: availableProviders.has(id),
       modelCount,
+      authType: OAUTH_PROVIDER_IDS.has(id) ? ("oauth" as const) : ("api-key" as const),
     }))
     .sort((a, b) => a.name.localeCompare(b.name))
 }
@@ -163,6 +184,25 @@ export async function setAgentApiKey(args: { providerID: string; apiKey: string 
   const pi = await loadPi()
   const authStorage = pi.AuthStorage.create(path.join(getPiAgentDir(), "auth.json"))
   authStorage.set(args.providerID, { type: "api_key", key: args.apiKey })
+}
+
+export async function loginAgentOAuthProvider(
+  args: { providerID: string },
+  openExternal: (url: string) => Promise<void>,
+): Promise<void> {
+  const pi = await loadPi()
+  const authStorage = pi.AuthStorage.create(path.join(getPiAgentDir(), "auth.json"))
+  await authStorage.login(args.providerID, {
+    onAuth: async ({ url }) => {
+      await openExternal(url)
+    },
+    onPrompt: async () => {
+      throw new Error("Browser OAuth callback did not complete. Please try again.")
+    },
+    onProgress: (message) => {
+      console.log(`[pi oauth:${args.providerID}] ${message}`)
+    },
+  })
 }
 
 export async function createAgentSessionForDirectory(args: {
@@ -196,9 +236,15 @@ export async function promptAgentSession(args: {
   directory: string
   text: string
   images?: Array<{ type: "image"; data: string; mimeType: string }>
-  model?: { providerID: string; modelID: string } | null
+  model?: RequestedAgentModel | null
+  thinkingLevel?: AgentThinkingLevel
 }): Promise<void> {
-  const runtime = await ensureRuntimeSession(args.sessionID, args.directory, args.model)
+  const runtime = await ensureRuntimeSession(
+    args.sessionID,
+    args.directory,
+    args.model,
+    args.thinkingLevel,
+  )
   emitSessionStatus(runtime.id, "running")
   void runtime.session.prompt(args.text, { images: args.images }).catch((error: unknown) => {
     emitSessionError(runtime.id, error)
@@ -297,9 +343,10 @@ export async function navigateAgentTree(args: {
 
 async function createRuntimeSession(
   cwd: string,
-  requestedModel?: { providerID: string; modelID: string } | null,
+  requestedModel?: RequestedAgentModel | null,
+  thinkingLevel?: AgentThinkingLevel,
 ): Promise<RuntimeSession> {
-  const { session } = await createPiSession(cwd, undefined, requestedModel)
+  const { session } = await createPiSession(cwd, undefined, requestedModel, thinkingLevel)
   const runtime = bindRuntimeSession(session, cwd)
   sessions.set(runtime.id, runtime)
   return runtime
@@ -308,26 +355,50 @@ async function createRuntimeSession(
 async function ensureRuntimeSession(
   sessionID: string,
   cwd: string,
-  requestedModel?: { providerID: string; modelID: string } | null,
+  requestedModel?: RequestedAgentModel | null,
+  thinkingLevel?: AgentThinkingLevel,
 ): Promise<RuntimeSession> {
   const existing = sessions.get(sessionID)
-  if (existing) return existing
+  if (existing) {
+    await applyRuntimeModelOptions(existing, requestedModel, thinkingLevel)
+    return existing
+  }
 
   const sessionFile = await findSessionFile(cwd, sessionID)
   const pi = await loadPi()
   const sessionManager = sessionFile
     ? pi.SessionManager.open(sessionFile, getPiSessionDir(cwd), cwd)
     : pi.SessionManager.create(cwd, getPiSessionDir(cwd))
-  const { session } = await createPiSession(cwd, sessionManager, requestedModel)
+  const { session } = await createPiSession(cwd, sessionManager, requestedModel, thinkingLevel)
   const runtime = bindRuntimeSession(session, cwd)
   sessions.set(runtime.id, runtime)
   return runtime
 }
 
+async function applyRuntimeModelOptions(
+  runtime: RuntimeSession,
+  requestedModel?: RequestedAgentModel | null,
+  thinkingLevel?: AgentThinkingLevel,
+): Promise<void> {
+  if (requestedModel) {
+    const current = runtime.session.model
+    if (current?.provider !== requestedModel.providerID || current?.id !== requestedModel.modelID) {
+      const registry = await createModelRegistry()
+      const model = registry.find(requestedModel.providerID, requestedModel.modelID)
+      if (model) await runtime.session.setModel(model)
+    }
+  }
+
+  if (thinkingLevel) {
+    runtime.session.setThinkingLevel(thinkingLevel)
+  }
+}
+
 async function createPiSession(
   cwd: string,
   sessionManager?: SessionManager,
-  requestedModel?: { providerID: string; modelID: string } | null,
+  requestedModel?: RequestedAgentModel | null,
+  thinkingLevel?: AgentThinkingLevel,
 ) {
   await ensureDilagPiResources(cwd)
   const pi = await loadPi()
@@ -340,6 +411,7 @@ async function createPiSession(
     cwd,
     agentDir: getPiAgentDir(),
     model,
+    thinkingLevel,
     modelRegistry: registry,
     sessionManager,
     customTools: [questionTool],

--- a/apps/desktop/electron/ipc/pi.ts
+++ b/apps/desktop/electron/ipc/pi.ts
@@ -147,7 +147,10 @@ export async function getAgentProviderData(): Promise<AgentProviderData> {
   }
 }
 
-function getThinkingLevelVariants(model: { reasoning?: boolean; thinkingLevelMap?: Partial<Record<AgentThinkingLevel, string | null>> }) {
+function getThinkingLevelVariants(model: {
+  reasoning?: boolean
+  thinkingLevelMap?: Partial<Record<AgentThinkingLevel, string | null>>
+}) {
   if (!model.reasoning) return undefined
   const levels: AgentThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh"]
   const available = levels.filter((level) => {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -44,6 +44,7 @@ const bridge: DesktopBridge = {
     getProviderData: () => ipcRenderer.invoke(CHANNELS.agent.getProviderData),
     listProviders: () => ipcRenderer.invoke(CHANNELS.agent.listProviders),
     setApiKey: (args) => ipcRenderer.invoke(CHANNELS.agent.setApiKey, args),
+    loginOAuthProvider: (args) => ipcRenderer.invoke(CHANNELS.agent.loginOAuthProvider, args),
     createSession: (args) => ipcRenderer.invoke(CHANNELS.agent.createSession, args),
     getSession: (args) => ipcRenderer.invoke(CHANNELS.agent.getSession, args),
     getMessages: (args) => ipcRenderer.invoke(CHANNELS.agent.getMessages, args),

--- a/apps/desktop/electron/shared/channels.ts
+++ b/apps/desktop/electron/shared/channels.ts
@@ -16,6 +16,7 @@ export const CHANNELS = {
     getProviderData: "agent:get-provider-data",
     listProviders: "agent:list-providers",
     setApiKey: "agent:set-api-key",
+    loginOAuthProvider: "agent:login-oauth-provider",
     createSession: "agent:create-session",
     getSession: "agent:get-session",
     getMessages: "agent:get-messages",

--- a/apps/desktop/src/components/ai-elements/model-selector.tsx
+++ b/apps/desktop/src/components/ai-elements/model-selector.tsx
@@ -154,7 +154,6 @@ export type ModelSelectorLogoProps = Omit<ComponentProps<"img">, "src" | "alt"> 
     | "azure"
     | "baseten"
     | "huggingface"
-    | "opencode"
     | "fastrouter"
     | "google"
     | "google-vertex"

--- a/apps/desktop/src/components/app-providers.tsx
+++ b/apps/desktop/src/components/app-providers.tsx
@@ -31,7 +31,7 @@ interface AppProvidersProps {
  * 1. ErrorBoundary - Catches React errors
  * 2. ThemeProvider - Dark/light mode
  * 3. QueryClientProvider - React Query for server state
- * 4. GlobalEventsProvider - SSE connection to OpenCode
+ * 4. GlobalEventsProvider - Pi agent event bridge
  * 5. NotificationProvider - Audio notifications
  * 6. UpdaterProvider - App updates
  * 7. MenuEventsProvider - Native menu events

--- a/apps/desktop/src/components/blocks/dialogs/dialog-connect-provider.tsx
+++ b/apps/desktop/src/components/blocks/dialogs/dialog-connect-provider.tsx
@@ -1,15 +1,12 @@
-import { useState, useEffect } from "react"
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
-import { ArrowLeft, Restart, DangerCircle, Copy, CheckCircle } from "@solar-icons/react"
-import { useSDK } from "@/context/global-events"
+import { useEffect, useState } from "react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { ArrowLeft, DangerCircle, Restart } from "@solar-icons/react"
 import { Dialog, DialogContent } from "@dilag/ui/dialog"
 import { Input } from "@dilag/ui/input"
-import { Field, FieldLabel, FieldDescription } from "@dilag/ui/field"
+import { Field, FieldLabel } from "@dilag/ui/field"
 import { cn } from "@/lib/utils"
 import { toast } from "sonner"
 import { bridge } from "@/lib/bridge"
-
-type AuthState = "select-method" | "pending" | "api-key" | "oauth-code" | "oauth-auto" | "error"
 
 interface DialogConnectProviderProps {
   open: boolean
@@ -19,6 +16,10 @@ interface DialogConnectProviderProps {
   onSuccess: () => void
 }
 
+type AuthMode = "api-key" | "oauth"
+
+const OPENAI_CODEX_PROVIDER_ID = "openai-codex"
+
 export function DialogConnectProvider({
   open,
   onOpenChange,
@@ -26,199 +27,89 @@ export function DialogConnectProvider({
   onBack,
   onSuccess,
 }: DialogConnectProviderProps) {
-  const sdk = useSDK()
   const queryClient = useQueryClient()
-
-  const [authState, setAuthState] = useState<AuthState>("select-method")
-  const [selectedMethodIndex, setSelectedMethodIndex] = useState<number | null>(null)
-  const [authorization, setAuthorization] = useState<{
-    url?: string
-    method?: "code" | "auto"
-    instructions?: string
-  } | null>(null)
   const [apiKey, setApiKey] = useState("")
-  const [authCode, setAuthCode] = useState("")
+  const [authMode, setAuthMode] = useState<AuthMode>("api-key")
   const [error, setError] = useState<string | null>(null)
 
-  // Fetch provider info
-  const { data: provider } = useQuery({
-    queryKey: ["provider", providerId],
-    queryFn: async () => {
-      const response = await sdk.provider.list()
-      return response.data?.all?.find((p) => p.id === providerId)
-    },
-    enabled: open && !!providerId,
+  const { data: providers = [] } = useQuery({
+    queryKey: ["providers", "all"],
+    queryFn: () => bridge.agent.listProviders(),
+    enabled: open,
   })
+  const provider = providers.find((p) => p.id === providerId)
+  const providerName = provider?.name ?? providerId
+  const isOAuthProvider = provider?.authType === "oauth"
+  const showsOpenAIAuthChoices = providerId === "openai"
+  const oauthProviderId = showsOpenAIAuthChoices ? OPENAI_CODEX_PROVIDER_ID : providerId
 
-  // Fetch auth methods for this provider
-  const { data: authMethods = [] } = useQuery({
-    queryKey: ["provider-auth", providerId],
-    queryFn: async () => {
-      const response = await sdk.provider.auth()
-      const methods = response.data?.[providerId]
-      // Default to API key if no methods defined
-      return methods ?? [{ type: "api" as const, label: "API key" }]
-    },
-    enabled: open && !!providerId,
-  })
-
-  // Auto-select if only one method
-  useEffect(() => {
-    if (authMethods.length === 1 && authState === "select-method") {
-      selectMethod(0)
-    }
-  }, [authMethods, authState])
-
-  // Reset state when dialog closes or provider changes
   useEffect(() => {
     if (!open) {
-      setAuthState("select-method")
-      setSelectedMethodIndex(null)
-      setAuthorization(null)
       setApiKey("")
-      setAuthCode("")
       setError(null)
+      setAuthMode("api-key")
+      return
     }
-  }, [open, providerId])
 
-  // API key mutation
+    setAuthMode(isOAuthProvider ? "oauth" : "api-key")
+  }, [isOAuthProvider, open, providerId])
+
+  async function refreshProviderQueries() {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ["providers"] }),
+      queryClient.invalidateQueries({ queryKey: ["models"] }),
+    ])
+  }
+
   const apiKeyMutation = useMutation({
-    mutationFn: async (key: string) => {
-      await sdk.auth.set({
-        providerID: providerId,
-        auth: { type: "api", key },
-      })
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["auth", "providers"] })
-      toast.success(`${provider?.name} connected`, {
-        description: `${provider?.name} models are now available to use.`,
+    mutationFn: (key: string) => bridge.agent.setApiKey({ providerID: providerId, apiKey: key }),
+    onSuccess: async () => {
+      await refreshProviderQueries()
+      toast.success(`${providerName} connected`, {
+        description: `${providerName} models are now available to use.`,
       })
       onSuccess()
     },
     onError: (err) => {
       setError(err instanceof Error ? err.message : "Failed to save API key")
-      setAuthState("error")
     },
   })
 
-  // OAuth callback mutation
-  const oauthCallbackMutation = useMutation({
-    mutationFn: async ({ code, method }: { code?: string; method?: number }) => {
-      await sdk.provider.oauth.callback({
-        providerID: providerId,
-        code,
-        method,
-      })
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["auth", "providers"] })
-      toast.success(`${provider?.name} connected`, {
-        description: `${provider?.name} models are now available to use.`,
+  const oauthMutation = useMutation({
+    mutationFn: () => bridge.agent.loginOAuthProvider({ providerID: oauthProviderId }),
+    onSuccess: async () => {
+      await refreshProviderQueries()
+      toast.success("ChatGPT Codex connected", {
+        description: "Codex subscription models are now available to use.",
       })
       onSuccess()
     },
     onError: (err) => {
-      setError(err instanceof Error ? err.message : "Authorization failed")
-      setAuthState("error")
+      setError(err instanceof Error ? err.message : "OAuth login failed")
     },
   })
-
-  async function selectMethod(index: number) {
-    const method = authMethods[index]
-    setSelectedMethodIndex(index)
-    setError(null)
-
-    if (method.type === "api") {
-      setAuthState("api-key")
-      return
-    }
-
-    // OAuth flow
-    setAuthState("pending")
-    try {
-      const response = await sdk.provider.oauth.authorize({
-        providerID: providerId,
-        method: index,
-      })
-
-      if (response.data?.url) {
-        setAuthorization({
-          url: response.data.url,
-          method: response.data.method as "code" | "auto",
-          instructions: response.data.instructions,
-        })
-
-        // Open URL in browser
-        await bridge.shell.openExternal(response.data.url)
-
-        if (response.data.method === "auto") {
-          setAuthState("oauth-auto")
-          // Start polling for completion
-          oauthCallbackMutation.mutate({ method: index })
-        } else {
-          setAuthState("oauth-code")
-        }
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to start authorization")
-      setAuthState("error")
-    }
-  }
 
   function handleSubmitApiKey(e: React.FormEvent) {
     e.preventDefault()
     if (!apiKey.trim()) return
+    setError(null)
     apiKeyMutation.mutate(apiKey.trim())
   }
 
-  function handleSubmitAuthCode(e: React.FormEvent) {
-    e.preventDefault()
-    if (!authCode.trim()) return
-    oauthCallbackMutation.mutate({ code: authCode.trim(), method: selectedMethodIndex ?? 0 })
+  function handleOAuthLogin() {
+    setError(null)
+    oauthMutation.mutate()
   }
 
-  function handleBack() {
-    if (authMethods.length === 1) {
-      onBack()
-      return
-    }
-    if (authState !== "select-method") {
-      setAuthState("select-method")
-      setSelectedMethodIndex(null)
-      setAuthorization(null)
-      setApiKey("")
-      setAuthCode("")
-      setError(null)
-      return
-    }
-    onBack()
-  }
-
-  const selectedMethod = selectedMethodIndex !== null ? authMethods[selectedMethodIndex] : null
-  const [copied, setCopied] = useState(false)
-
-  const handleCopyCode = (code: string) => {
-    navigator.clipboard.writeText(code)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
-  }
-
-  const getTitle = () => {
-    if (providerId === "anthropic" && selectedMethod?.label?.toLowerCase().includes("max")) {
-      return "Login with Claude Pro/Max"
-    }
-    return `Connect ${provider?.name ?? providerId}`
-  }
+  const connectButtonPending = apiKeyMutation.isPending || oauthMutation.isPending
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="p-0 gap-0 max-w-[380px] overflow-hidden border-border/50 shadow-2xl">
-        {/* Header */}
         <div className="px-5 pt-5 pb-4">
           <div className="flex items-center gap-3">
             <button
-              onClick={handleBack}
+              onClick={onBack}
               className={cn(
                 "size-8 rounded-lg flex items-center justify-center",
                 "transition-colors duration-150",
@@ -235,86 +126,83 @@ export function DialogConnectProvider({
                 className="size-5 dark:invert"
               />
             </div>
-            <h2 className="text-base font-medium tracking-tight">{getTitle()}</h2>
+            <h2 className="text-base font-medium tracking-tight">Connect {providerName}</h2>
           </div>
         </div>
 
-        {/* Content */}
         <div className="px-5 pb-5 space-y-4">
-          {/* Method Selection */}
-          {authState === "select-method" && authMethods.length > 1 && (
-            <div className="space-y-3">
-              <p className="text-sm text-muted-foreground">Select how you want to authenticate</p>
-              <div className="space-y-1.5">
-                {authMethods.map((method, index) => (
-                  <button
-                    key={method.label}
-                    onClick={() => selectMethod(index)}
-                    className={cn(
-                      "w-full flex items-center gap-3 px-3 py-2.5 rounded-lg",
-                      "transition-colors duration-150 text-left",
-                      "hover:bg-muted/80 active:bg-muted",
-                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                    )}
-                  >
-                    <div className="size-4 rounded-full border-2 border-muted-foreground/30" />
-                    <span className="text-sm">{method.label}</span>
-                  </button>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Pending state */}
-          {authState === "pending" && (
-            <div className="py-6 flex flex-col items-center gap-3">
-              <Restart size={20} className="animate-spin text-muted-foreground" />
-              <p className="text-sm text-muted-foreground">Starting authorization...</p>
-            </div>
-          )}
-
-          {/* Error state */}
-          {authState === "error" && (
+          {error && (
             <div className="p-3 rounded-lg bg-destructive/10 border border-destructive/20">
               <div className="flex items-start gap-2">
                 <DangerCircle size={16} className="text-destructive mt-0.5 shrink-0" />
                 <div className="space-y-1">
-                  <p className="text-sm font-medium text-destructive">Authorization failed</p>
+                  <p className="text-sm font-medium text-destructive">Connection failed</p>
                   <p className="text-xs text-destructive/80">{error}</p>
                 </div>
               </div>
             </div>
           )}
 
-          {/* API Key input */}
-          {authState === "api-key" && (
+          {showsOpenAIAuthChoices && (
+            <div className="grid grid-cols-2 gap-2">
+              <button
+                type="button"
+                onClick={() => setAuthMode("api-key")}
+                className={cn(
+                  "rounded-lg border px-3 py-2 text-left transition-colors",
+                  authMode === "api-key" ? "border-primary bg-primary/10" : "hover:bg-muted/60",
+                )}
+              >
+                <span className="block text-sm font-medium">API key</span>
+                <span className="block text-xs text-muted-foreground">OpenAI Platform</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setAuthMode("oauth")}
+                className={cn(
+                  "rounded-lg border px-3 py-2 text-left transition-colors",
+                  authMode === "oauth" ? "border-primary bg-primary/10" : "hover:bg-muted/60",
+                )}
+              >
+                <span className="block text-sm font-medium">Codex OAuth</span>
+                <span className="block text-xs text-muted-foreground">ChatGPT Plus/Pro</span>
+              </button>
+            </div>
+          )}
+
+          {authMode === "oauth" ? (
             <div className="space-y-4">
-              {providerId === "opencode" ? (
-                <div className="space-y-2 text-sm text-muted-foreground">
-                  <p>
-                    OpenCode Zen gives you access to a curated set of reliable optimized models for
-                    coding agents.
-                  </p>
-                  <p>
-                    With a single API key you'll get access to models such as Claude, GPT, Gemini,
-                    GLM and more.
-                  </p>
-                  <p>
-                    Visit{" "}
-                    <button
-                      onClick={() => bridge.shell.openExternal("https://opencode.ai/zen")}
-                      className="text-primary hover:underline font-medium"
-                    >
-                      opencode.ai/zen
-                    </button>{" "}
-                    to get your API key.
-                  </p>
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">
-                  Enter your {provider?.name} API key to connect and access {provider?.name} models.
-                </p>
-              )}
+              <p className="text-sm text-muted-foreground">
+                Connect ChatGPT Plus/Pro with Pi's Codex OAuth flow. Dilag will open your browser;
+                finish login there and return to the app when it completes.
+              </p>
+              <button
+                type="button"
+                onClick={handleOAuthLogin}
+                disabled={connectButtonPending}
+                className={cn(
+                  "w-full h-9 rounded-lg text-sm font-medium",
+                  "bg-primary text-primary-foreground",
+                  "hover:bg-primary/90 transition-colors",
+                  "disabled:opacity-50 disabled:cursor-not-allowed",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                )}
+              >
+                {oauthMutation.isPending ? (
+                  <span className="flex items-center justify-center gap-2">
+                    <Restart size={14} className="animate-spin" />
+                    Waiting for browser login...
+                  </span>
+                ) : (
+                  "Continue with ChatGPT"
+                )}
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                Enter your {providerName} API key to make its Pi models available in Dilag.
+              </p>
               <form onSubmit={handleSubmitApiKey} className="space-y-4">
                 <Field>
                   <FieldLabel htmlFor="api-key">API Key</FieldLabel>
@@ -329,7 +217,7 @@ export function DialogConnectProvider({
                 </Field>
                 <button
                   type="submit"
-                  disabled={!apiKey.trim() || apiKeyMutation.isPending}
+                  disabled={!apiKey.trim() || connectButtonPending}
                   className={cn(
                     "w-full h-9 rounded-lg text-sm font-medium",
                     "bg-primary text-primary-foreground",
@@ -348,122 +236,6 @@ export function DialogConnectProvider({
                   )}
                 </button>
               </form>
-            </div>
-          )}
-
-          {/* OAuth Code input */}
-          {authState === "oauth-code" && authorization && (
-            <div className="space-y-4">
-              <p className="text-sm text-muted-foreground">
-                Complete authorization in your browser, then paste the code below.
-              </p>
-              <button
-                onClick={() => authorization.url && bridge.shell.openExternal(authorization.url)}
-                className={cn(
-                  "w-full h-9 rounded-lg text-sm font-medium",
-                  "border border-border/50 bg-muted/30",
-                  "hover:bg-muted/50 transition-colors",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                )}
-              >
-                Open {provider?.name} in browser
-              </button>
-              <form onSubmit={handleSubmitAuthCode} className="space-y-4">
-                <Field>
-                  <FieldLabel htmlFor="auth-code">Authorization Code</FieldLabel>
-                  <Input
-                    id="auth-code"
-                    type="text"
-                    placeholder="Paste code here..."
-                    value={authCode}
-                    onChange={(e) => setAuthCode(e.target.value)}
-                    autoFocus
-                    className="font-mono"
-                  />
-                </Field>
-                <button
-                  type="submit"
-                  disabled={!authCode.trim() || oauthCallbackMutation.isPending}
-                  className={cn(
-                    "w-full h-9 rounded-lg text-sm font-medium",
-                    "bg-primary text-primary-foreground",
-                    "hover:bg-primary/90 transition-colors",
-                    "disabled:opacity-50 disabled:cursor-not-allowed",
-                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                  )}
-                >
-                  {oauthCallbackMutation.isPending ? (
-                    <span className="flex items-center justify-center gap-2">
-                      <Restart size={14} className="animate-spin" />
-                      Verifying...
-                    </span>
-                  ) : (
-                    "Verify"
-                  )}
-                </button>
-              </form>
-            </div>
-          )}
-
-          {/* OAuth Auto (device code) */}
-          {authState === "oauth-auto" && authorization && (
-            <div className="space-y-4">
-              <p className="text-sm text-muted-foreground">
-                A browser window has opened. Enter the code below to complete authorization.
-              </p>
-              {authorization.instructions && (
-                <Field>
-                  <FieldLabel>Your Code</FieldLabel>
-                  <div className="relative">
-                    <Input
-                      value={
-                        authorization.instructions.includes(":")
-                          ? authorization.instructions.split(":")[1]?.trim()
-                          : authorization.instructions
-                      }
-                      readOnly
-                      className="h-11 font-mono text-base tracking-widest text-center pr-10"
-                    />
-                    <button
-                      type="button"
-                      onClick={() =>
-                        handleCopyCode(
-                          authorization.instructions?.includes(":")
-                            ? (authorization.instructions.split(":")[1]?.trim() ?? "")
-                            : (authorization.instructions ?? ""),
-                        )
-                      }
-                      className={cn(
-                        "absolute right-2 top-1/2 -translate-y-1/2",
-                        "size-7 rounded flex items-center justify-center",
-                        "hover:bg-muted transition-colors",
-                      )}
-                    >
-                      {copied ? (
-                        <CheckCircle size={14} className="text-emerald-600" />
-                      ) : (
-                        <Copy size={14} className="text-muted-foreground" />
-                      )}
-                    </button>
-                  </div>
-                  <FieldDescription>Copy this code and paste it in your browser</FieldDescription>
-                </Field>
-              )}
-              <button
-                onClick={() => authorization.url && bridge.shell.openExternal(authorization.url)}
-                className={cn(
-                  "w-full h-9 rounded-lg text-sm font-medium",
-                  "border border-border/50 bg-muted/30",
-                  "hover:bg-muted/50 transition-colors",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                )}
-              >
-                Reopen browser window
-              </button>
-              <div className="flex items-center justify-center gap-2 py-2">
-                <Restart size={14} className="animate-spin text-muted-foreground" />
-                <span className="text-sm text-muted-foreground">Waiting for authorization...</span>
-              </div>
             </div>
           )}
         </div>

--- a/apps/desktop/src/components/blocks/dialogs/dialog-select-provider.tsx
+++ b/apps/desktop/src/components/blocks/dialogs/dialog-select-provider.tsx
@@ -1,20 +1,15 @@
 import { useState, useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { CheckCircle, Magnifer, AltArrowDown } from "@solar-icons/react"
-import { useSDK } from "@/context/global-events"
 import { Dialog, DialogContent } from "@dilag/ui/dialog"
 import { Input } from "@dilag/ui/input"
 import { cn } from "@/lib/utils"
+import { bridge } from "@/lib/bridge"
 
-// Popular providers to show at top
-const POPULAR_PROVIDERS = [
-  "opencode",
-  "anthropic",
-  "github-copilot",
-  "openai",
-  "google",
-  "openrouter",
-]
+// Providers to show at top, in preferred setup order.
+const POPULAR_PROVIDERS = ["opencode-go", "openai", "google", "openrouter", "mistral"]
+
+const RECOMMENDED_PROVIDER_IDS = new Set(["opencode-go", "openai"])
 
 interface DialogSelectProviderProps {
   open: boolean
@@ -27,36 +22,31 @@ export function DialogSelectProvider({
   onOpenChange,
   onSelectProvider,
 }: DialogSelectProviderProps) {
-  const sdk = useSDK()
   const [search, setSearch] = useState("")
   const [othersExpanded, setOthersExpanded] = useState(false)
 
   // Fetch all providers and connected status
   const { data: providerData } = useQuery({
     queryKey: ["providers", "all"],
-    queryFn: async () => {
-      const response = await sdk.provider.list()
-      return {
-        all: response.data?.all ?? [],
-        connected: response.data?.connected ?? [],
-      }
-    },
+    queryFn: () => bridge.agent.listProviders(),
     enabled: open,
   })
 
-  const allProviders = providerData?.all ?? []
-  const connectedProviders = providerData?.connected ?? []
+  const allProviders = providerData ?? []
 
   // Split providers into popular and others, apply search
   const { popularProviders, otherProviders } = useMemo(() => {
     const query = search.trim().toLowerCase()
 
+    const codexConnected = allProviders.some((p) => p.id === "openai-codex" && p.connected)
+
     const popular = allProviders
       .filter((p) => POPULAR_PROVIDERS.includes(p.id))
+      .map((p) => (p.id === "openai" ? { ...p, connected: p.connected || codexConnected } : p))
       .sort((a, b) => POPULAR_PROVIDERS.indexOf(a.id) - POPULAR_PROVIDERS.indexOf(b.id))
 
     const others = allProviders
-      .filter((p) => !POPULAR_PROVIDERS.includes(p.id))
+      .filter((p) => !POPULAR_PROVIDERS.includes(p.id) && (query || p.id !== "openai-codex"))
       .sort((a, b) => a.name.localeCompare(b.name))
 
     if (query) {
@@ -110,7 +100,6 @@ export function DialogSelectProvider({
             <div className="space-y-0.5">
               {/* Popular providers */}
               {popularProviders.map((provider) => {
-                const isConnected = connectedProviders.includes(provider.id)
                 return (
                   <button
                     key={provider.id}
@@ -132,14 +121,19 @@ export function DialogSelectProvider({
                     <div className="flex-1 text-left">
                       <div className="flex items-center gap-2">
                         <span className="text-sm font-medium">{provider.name}</span>
-                        {provider.id === "opencode" && !isConnected && (
+                        {!provider.connected && RECOMMENDED_PROVIDER_IDS.has(provider.id) && (
                           <span className="text-[10px] font-medium uppercase tracking-wider text-primary px-1.5 py-0.5 rounded bg-primary/10">
                             Recommended
                           </span>
                         )}
+                        {provider.authType === "oauth" && (
+                          <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground px-1.5 py-0.5 rounded bg-muted">
+                            Subscription
+                          </span>
+                        )}
                       </div>
                     </div>
-                    {isConnected && (
+                    {provider.connected && (
                       <div className="size-5 rounded-full bg-emerald-500/10 flex items-center justify-center">
                         <CheckCircle size={12} className="text-emerald-600" />
                       </div>
@@ -171,7 +165,6 @@ export function DialogSelectProvider({
                   {othersExpanded && (
                     <div className="space-y-0.5">
                       {otherProviders.map((provider) => {
-                        const isConnected = connectedProviders.includes(provider.id)
                         return (
                           <button
                             key={provider.id}
@@ -193,7 +186,12 @@ export function DialogSelectProvider({
                             <span className="text-sm font-medium text-left flex-1">
                               {provider.name}
                             </span>
-                            {isConnected && (
+                            {provider.authType === "oauth" && (
+                              <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground px-1.5 py-0.5 rounded bg-muted">
+                                Subscription
+                              </span>
+                            )}
+                            {provider.connected && (
                               <div className="size-5 rounded-full bg-emerald-500/10 flex items-center justify-center">
                                 <CheckCircle size={12} className="text-emerald-600" />
                               </div>

--- a/apps/desktop/src/components/blocks/selectors/model-selector-button.tsx
+++ b/apps/desktop/src/components/blocks/selectors/model-selector-button.tsx
@@ -24,13 +24,7 @@ type ProviderDialogState =
   | { type: "connect-provider"; providerId: string }
 
 // Popular providers in priority order
-const PROVIDER_PRIORITY = [
-  "anthropic",
-  "openai",
-  "google",
-  "github-copilot",
-  "openrouter",
-]
+const PROVIDER_PRIORITY = ["anthropic", "openai", "google", "github-copilot", "openrouter"]
 
 interface ModelSelectorButtonProps {
   variant?: "default" | "settings"

--- a/apps/desktop/src/components/blocks/selectors/model-selector-button.tsx
+++ b/apps/desktop/src/components/blocks/selectors/model-selector-button.tsx
@@ -25,7 +25,6 @@ type ProviderDialogState =
 
 // Popular providers in priority order
 const PROVIDER_PRIORITY = [
-  "opencode",
   "anthropic",
   "openai",
   "google",

--- a/apps/desktop/src/components/blocks/setup/setup-wizard.test.tsx
+++ b/apps/desktop/src/components/blocks/setup/setup-wizard.test.tsx
@@ -4,166 +4,100 @@ import { SetupWizard } from "./setup-wizard"
 
 describe("SetupWizard", () => {
   const mockOnComplete = vi.fn()
-  const mockCheckOpenCode = vi.mocked(window.desktopBridge!.opencode!.checkInstallation)
-  const mockCheckBun = vi.mocked(window.desktopBridge!.opencode!.checkBunInstallation)
+  const mockStartAgent = vi.mocked(window.desktopBridge!.agent.start)
 
   beforeEach(() => {
     vi.clearAllMocks()
-    mockCheckOpenCode.mockReset()
-    mockCheckBun.mockReset()
+    mockStartAgent.mockReset()
   })
 
-  describe("dependency checking", () => {
-    it("should check OpenCode first, then Bun", async () => {
-      mockCheckOpenCode.mockResolvedValueOnce({ installed: true, version: "1.0.0", error: null })
-      mockCheckBun.mockResolvedValueOnce({ installed: true, version: "1.1.0", error: null })
-
-      render(<SetupWizard onComplete={mockOnComplete} />)
-
-      await waitFor(() => {
-        expect(mockCheckOpenCode).toHaveBeenCalled()
-      })
-
-      await waitFor(() => {
-        expect(mockCheckBun).toHaveBeenCalled()
-      })
-
-      expect(mockCheckOpenCode).toHaveBeenCalledTimes(1)
-      expect(mockCheckBun).toHaveBeenCalledTimes(1)
+  it("starts the embedded Pi runtime", async () => {
+    mockStartAgent.mockResolvedValueOnce({
+      running: true,
+      agentDir: "~/.dilag/pi",
+      sessionCount: 0,
     })
 
-    it("should show checking state initially", () => {
-      mockCheckOpenCode.mockImplementation(() => new Promise(() => {}))
+    render(<SetupWizard onComplete={mockOnComplete} />)
 
-      render(<SetupWizard onComplete={mockOnComplete} />)
-
-      expect(screen.getByText("Checking setup...")).toBeInTheDocument()
-    })
-
-    it("should call onComplete when both dependencies are installed", async () => {
-      mockCheckOpenCode.mockResolvedValueOnce({ installed: true, version: "1.0.0", error: null })
-      mockCheckBun.mockResolvedValueOnce({ installed: true, version: "1.1.0", error: null })
-
-      render(<SetupWizard onComplete={mockOnComplete} />)
-
-      await waitFor(() => {
-        expect(screen.getByText("Ready")).toBeInTheDocument()
-      })
-
-      await waitFor(
-        () => {
-          expect(mockOnComplete).toHaveBeenCalled()
-        },
-        { timeout: 1500 },
-      )
-    })
-
-    it("should show missing state when OpenCode is missing", async () => {
-      mockCheckOpenCode.mockResolvedValueOnce({
-        installed: false,
-        version: null,
-        error: "OpenCode CLI not found",
-      })
-
-      render(<SetupWizard onComplete={mockOnComplete} />)
-
-      await waitFor(() => {
-        expect(screen.getByText("Install required dependencies")).toBeInTheDocument()
-      })
-
-      expect(mockCheckOpenCode).toHaveBeenCalledTimes(1)
-      expect(mockCheckBun).not.toHaveBeenCalled()
-      expect(mockOnComplete).not.toHaveBeenCalled()
-    })
-
-    it("should show missing state when Bun is missing", async () => {
-      mockCheckOpenCode.mockResolvedValueOnce({ installed: true, version: "1.0.0", error: null })
-      mockCheckBun.mockResolvedValueOnce({
-        installed: false,
-        version: null,
-        error: "Bun not found",
-      })
-
-      render(<SetupWizard onComplete={mockOnComplete} />)
-
-      await waitFor(() => {
-        expect(screen.getByText("Install required dependencies")).toBeInTheDocument()
-      })
-
-      expect(mockCheckOpenCode).toHaveBeenCalledTimes(1)
-      expect(mockCheckBun).toHaveBeenCalledTimes(1)
-      expect(mockOnComplete).not.toHaveBeenCalled()
-    })
-
-    it("should show install and skip actions when dependencies are missing", async () => {
-      mockCheckOpenCode.mockResolvedValueOnce({
-        installed: false,
-        version: null,
-        error: null,
-      })
-
-      render(<SetupWizard onComplete={mockOnComplete} />)
-
-      await waitFor(() => {
-        expect(screen.getByText("Install")).toBeInTheDocument()
-        expect(screen.getByText("Skip")).toBeInTheDocument()
-      })
+    await waitFor(() => {
+      expect(mockStartAgent).toHaveBeenCalledTimes(1)
+      expect(screen.getByText("Ready")).toBeInTheDocument()
     })
   })
 
-  describe("retry functionality", () => {
-    it("should retry checking dependencies when 'Try again' is clicked", async () => {
-      mockCheckOpenCode.mockRejectedValueOnce(new Error("Network error"))
+  it("shows checking state initially", () => {
+    mockStartAgent.mockImplementation(() => new Promise(() => {}))
 
-      render(<SetupWizard onComplete={mockOnComplete} />)
+    render(<SetupWizard onComplete={mockOnComplete} />)
 
-      await waitFor(() => {
-        expect(screen.getByText("Try again")).toBeInTheDocument()
-      })
+    expect(screen.getByText("Checking setup...")).toBeInTheDocument()
+  })
 
-      mockCheckOpenCode.mockResolvedValueOnce({ installed: true, version: "1.0.0", error: null })
-      mockCheckBun.mockResolvedValueOnce({ installed: true, version: "1.1.0", error: null })
+  it("calls onComplete when Pi is ready", async () => {
+    mockStartAgent.mockResolvedValueOnce({
+      running: true,
+      agentDir: "~/.dilag/pi",
+      sessionCount: 0,
+    })
 
-      fireEvent.click(screen.getByText("Try again"))
+    render(<SetupWizard onComplete={mockOnComplete} />)
 
-      await waitFor(() => {
-        expect(mockCheckOpenCode).toHaveBeenCalledTimes(2)
-      })
+    await waitFor(
+      () => {
+        expect(mockOnComplete).toHaveBeenCalled()
+      },
+      { timeout: 1500 },
+    )
+  })
 
-      expect(mockCheckBun).toHaveBeenCalledTimes(1)
+  it("shows error actions when Pi startup fails", async () => {
+    mockStartAgent.mockRejectedValueOnce(new Error("Pi startup failed"))
+
+    render(<SetupWizard onComplete={mockOnComplete} />)
+
+    await waitFor(() => {
+      expect(screen.getByText("Setup failed")).toBeInTheDocument()
+      expect(screen.getByText("Pi startup failed")).toBeInTheDocument()
+      expect(screen.getByText("Try again")).toBeInTheDocument()
+      expect(screen.getByText("Skip")).toBeInTheDocument()
     })
   })
 
-  describe("continue anyway", () => {
-    it("should allow user to skip setup when dependency is missing", async () => {
-      mockCheckOpenCode.mockResolvedValue({
-        installed: false,
-        version: null,
-        error: null,
-      })
+  it("retries startup when Try again is clicked", async () => {
+    mockStartAgent.mockRejectedValueOnce(new Error("Network error"))
 
-      render(<SetupWizard onComplete={mockOnComplete} />)
+    render(<SetupWizard onComplete={mockOnComplete} />)
 
-      await waitFor(() => {
-        expect(screen.getByText("Skip")).toBeInTheDocument()
-      })
+    await waitFor(() => {
+      expect(screen.getByText("Try again")).toBeInTheDocument()
+    })
 
-      fireEvent.click(screen.getByText("Skip"))
+    mockStartAgent.mockResolvedValueOnce({
+      running: true,
+      agentDir: "~/.dilag/pi",
+      sessionCount: 0,
+    })
 
-      expect(mockOnComplete).toHaveBeenCalled()
+    fireEvent.click(screen.getByText("Try again"))
+
+    await waitFor(() => {
+      expect(mockStartAgent).toHaveBeenCalledTimes(2)
+      expect(screen.getByText("Ready")).toBeInTheDocument()
     })
   })
 
-  describe("error handling", () => {
-    it("should show error state when check throws", async () => {
-      mockCheckOpenCode.mockRejectedValueOnce(new Error("Network error"))
+  it("allows the user to skip setup after an error", async () => {
+    mockStartAgent.mockRejectedValueOnce(new Error("Pi startup failed"))
 
-      render(<SetupWizard onComplete={mockOnComplete} />)
+    render(<SetupWizard onComplete={mockOnComplete} />)
 
-      await waitFor(() => {
-        expect(screen.getByText("Setup failed")).toBeInTheDocument()
-        expect(screen.getByText("Network error")).toBeInTheDocument()
-      })
+    await waitFor(() => {
+      expect(screen.getByText("Skip")).toBeInTheDocument()
     })
+
+    fireEvent.click(screen.getByText("Skip"))
+
+    expect(mockOnComplete).toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/components/blocks/setup/setup-wizard.tsx
+++ b/apps/desktop/src/components/blocks/setup/setup-wizard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { bridge } from "@/lib/bridge"
 import { cn } from "@/lib/utils"
 
@@ -12,69 +12,27 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
   const [stage, setStage] = useState<SetupStage>("checking")
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-  const checkDependencies = async () => {
+  const checkDependencies = useCallback(async () => {
     setStage("checking")
     setErrorMessage(null)
 
     try {
-      const opencodeResult = (await bridge.opencode!.checkInstallation()) as {
-        installed: boolean
-        version: string | null
-        error: string | null
-      }
-
-      if (!opencodeResult.installed) {
-        setStage("missing")
-        return
-      }
-
-      const bunResult = (await bridge.opencode!.checkBunInstallation()) as {
-        installed: boolean
-        version: string | null
-        error: string | null
-      }
-
-      if (!bunResult.installed) {
-        setStage("missing")
-        return
-      }
-
+      await bridge.agent.start()
       setStage("installed")
       setTimeout(onComplete, 600)
     } catch (err) {
       setStage("error")
       setErrorMessage(err instanceof Error ? err.message : String(err))
     }
-  }
+  }, [onComplete])
 
   const handleInstall = async () => {
-    setStage("installing")
-    setErrorMessage(null)
-
-    try {
-      const result = (await bridge.opencode!.installDependencies()) as {
-        stage: string
-        message: string
-        completed: boolean
-        error: string | null
-      }
-
-      if (result.completed) {
-        // Re-check to confirm installation
-        await checkDependencies()
-      } else {
-        setStage("error")
-        setErrorMessage(result.error || result.message)
-      }
-    } catch (err) {
-      setStage("error")
-      setErrorMessage(err instanceof Error ? err.message : String(err))
-    }
+    await checkDependencies()
   }
 
   useEffect(() => {
     checkDependencies()
-  }, [])
+  }, [checkDependencies])
 
   return (
     <div className="h-screen w-screen flex items-center justify-center bg-background">
@@ -104,9 +62,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
           {stage === "missing" && (
             <>
               <p className="text-sm text-foreground">Install required dependencies</p>
-              <p className="text-xs text-muted-foreground">
-                OpenCode and Bun are needed to continue
-              </p>
+              <p className="text-xs text-muted-foreground">Pi runtime could not be initialized</p>
             </>
           )}
 

--- a/apps/desktop/src/hooks/use-models.ts
+++ b/apps/desktop/src/hooks/use-models.ts
@@ -1,12 +1,9 @@
 import { useCallback, useMemo, useState } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { useSDK } from "@/context/global-events"
 import { create } from "zustand"
 import { persist, createJSONStorage } from "zustand/middleware"
 import { bridge } from "@/lib/bridge"
-
-// Hot models to feature
-const HOT_MODELS = ["gemini-3-pro-preview", "claude-opus-4-5", "gpt-5.2"] as const
+import type { AgentThinkingLevel } from "@dilag/desktop-bridge"
 
 export interface Model {
   id: string
@@ -19,22 +16,21 @@ export interface Model {
   free?: boolean
   latest?: boolean
   cost?: { input?: number; output?: number }
-  variants?: Record<string, Record<string, unknown>>
+  variants?: Record<AgentThinkingLevel, Record<string, unknown>>
 }
 
 interface ModelState {
   selectedModel: { providerID: string; modelID: string } | null
   setSelectedModel: (model: { providerID: string; modelID: string } | null) => void
   // Variant state: key is "providerID/modelID", value is variant name
-  variants: Record<string, string | undefined>
-  setVariant: (modelKey: string, variant: string | undefined) => void
+  variants: Record<string, AgentThinkingLevel | undefined>
+  setVariant: (modelKey: string, variant: AgentThinkingLevel | undefined) => void
 }
 
 export const useModelStore = create<ModelState>()(
   persist(
     (set) => ({
-      // Default to Big Pickle
-      selectedModel: { providerID: "opencode", modelID: "big-pickle" },
+      selectedModel: null,
       setSelectedModel: (model) => set({ selectedModel: model }),
       variants: {},
       setVariant: (modelKey, variant) =>
@@ -58,102 +54,17 @@ export const modelKeys = {
 }
 
 /**
- * Check if a model is hot (featured)
- */
-function isHotModel(modelID: string): boolean {
-  return HOT_MODELS.some((hot) => modelID.includes(hot) || modelID.startsWith(hot))
-}
-
-/**
- * Check if a model is marked as latest based on its name
- */
-function isModelLatest(modelName: string): boolean {
-  return modelName.toLowerCase().includes("(latest)")
-}
-
-/**
- * Check if a model is free based on cost data (matching simon pattern)
- */
-function isModelFree(providerID: string, cost?: { input?: number; output?: number }): boolean {
-  if (providerID !== "opencode") return false
-  if (!cost) return true
-  return (cost.input ?? 0) === 0 && (cost.output ?? 0) === 0
-}
-
-/**
- * Transform raw provider data into Model array with hot/free flags
- */
-function transformProviderData(
-  providers: Array<{
-    id: string
-    name: string
-    models: Record<
-      string,
-      {
-        id?: string
-        name: string
-        release_date?: string
-        family?: string
-        cost?: { input?: number; output?: number }
-        variants?: Record<string, Record<string, unknown>>
-      }
-    >
-  }>,
-): Model[] {
-  const models: Model[] = []
-  const seenModels = new Set<string>()
-
-  for (const provider of providers) {
-    for (const [key, model] of Object.entries(provider.models)) {
-      const modelID = model.id || key
-      const dedupeKey = `${provider.id}:${modelID}`
-      if (seenModels.has(dedupeKey)) continue
-      seenModels.add(dedupeKey)
-
-      models.push({
-        id: modelID,
-        name: model.name.replace(/\s*\(latest\)\s*/i, "").trim(),
-        providerID: provider.id,
-        providerName: provider.name,
-        releaseDate: model.release_date,
-        family: model.family,
-        hot: isHotModel(modelID),
-        free: isModelFree(provider.id, model.cost),
-        latest: isModelLatest(model.name),
-        cost: model.cost,
-        variants: model.variants,
-      })
-    }
-  }
-
-  models.sort((a, b) => {
-    if (a.hot && !b.hot) return -1
-    if (!a.hot && b.hot) return 1
-    return a.name.localeCompare(b.name)
-  })
-
-  return models
-}
-
-/**
  * Hook to fetch provider/model data
  */
 export function useProviderData() {
-  const sdk = useSDK()
-
   return useQuery({
     queryKey: modelKeys.providers(),
     queryFn: async () => {
-      const response = await sdk.provider.list()
-      if (!response.data) {
-        throw new Error("No provider data received")
-      }
-      const connectedProviders = response.data.connected ?? []
-      const connectedSet = new Set(connectedProviders)
-      const connected = response.data.all.filter((p) => connectedSet.has(p.id))
+      const response = await bridge.agent.getProviderData()
       return {
-        models: transformProviderData(connected),
-        connectedProviders,
+        models: response.models,
+        connectedProviders: response.connectedProviders,
+        defaultModel: response.defaultModel,
       }
     },
     staleTime: 1000 * 60 * 5, // 5 minutes - models don't change often
@@ -171,6 +82,7 @@ export function useModels() {
 
   const models = data?.models ?? []
   const connectedProviders = data?.connectedProviders ?? []
+  const effectiveSelectedModel = selectedModel ?? data?.defaultModel ?? null
 
   const selectModel = useCallback(
     (providerID: string, modelID: string) => {
@@ -180,24 +92,26 @@ export function useModels() {
   )
 
   const selectedModelInfo = useMemo(() => {
-    if (!selectedModel) return null
+    if (!effectiveSelectedModel) return null
     return (
       models.find(
-        (m: Model) => m.providerID === selectedModel.providerID && m.id === selectedModel.modelID,
+        (m: Model) =>
+          m.providerID === effectiveSelectedModel.providerID &&
+          m.id === effectiveSelectedModel.modelID,
       ) ?? null
     )
-  }, [selectedModel, models])
+  }, [effectiveSelectedModel, models])
 
   // Get the model key for variant storage
   const modelKey = useMemo(() => {
-    if (!selectedModel) return null
-    return `${selectedModel.providerID}/${selectedModel.modelID}`
-  }, [selectedModel])
+    if (!effectiveSelectedModel) return null
+    return `${effectiveSelectedModel.providerID}/${effectiveSelectedModel.modelID}`
+  }, [effectiveSelectedModel])
 
   // Get available variants for current model
   const variantList = useMemo(() => {
     if (!selectedModelInfo?.variants) return []
-    return Object.keys(selectedModelInfo.variants)
+    return Object.keys(selectedModelInfo.variants) as AgentThinkingLevel[]
   }, [selectedModelInfo])
 
   // Get current variant for selected model
@@ -208,7 +122,7 @@ export function useModels() {
 
   // Set variant for current model
   const setCurrentVariant = useCallback(
-    (variant: string | undefined) => {
+    (variant: AgentThinkingLevel | undefined) => {
       if (!modelKey) return
       setVariant(modelKey, variant)
     },
@@ -236,18 +150,8 @@ export function useModels() {
   const restartServerAndRefresh = useCallback(async () => {
     setIsRestarting(true)
     try {
-      console.log("[useModels] Restarting OpenCode server...")
-      const port = await bridge.opencode!.restart()
-      console.log("[useModels] Server restarted on port:", port)
-      // Poll for server readiness (up to 10s)
-      for (let i = 0; i < 20; i++) {
-        try {
-          const res = await fetch(`http://127.0.0.1:${port}/health`)
-          if (res.ok) break
-        } catch {
-          await new Promise((r) => setTimeout(r, 500))
-        }
-      }
+      console.log("[useModels] Restarting agent runtime...")
+      await bridge.agent.restart()
       // Force refetch by invalidating and refetching
       console.log("[useModels] Refetching models...")
       await queryClient.resetQueries({ queryKey: modelKeys.all })
@@ -263,7 +167,7 @@ export function useModels() {
   return {
     models,
     connectedProviders,
-    selectedModel,
+    selectedModel: effectiveSelectedModel,
     selectedModelInfo,
     isLoading,
     isRestarting,

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -36,39 +36,20 @@ root.render(
   </React.StrictMode>,
 )
 
-// Check OpenCode installation BEFORE React renders (TkDodo/KCD approved pattern)
-// This avoids loading spinners and keeps prerequisite logic outside the component tree
+// Start the embedded Pi runtime before React renders.
+// This avoids loading spinners and keeps prerequisite logic outside the component tree.
 async function bootstrap() {
   try {
-    const result = (await bridge.opencode!.checkInstallation()) as { installed: boolean }
+    await bridge.agent.start()
 
-    if (result.installed) {
-      // OpenCode is ready - render the full app
-      root.render(
-        <React.StrictMode>
-          <RouterProvider router={router} />
-        </React.StrictMode>,
-      )
-      return
-    }
-
-    // OpenCode not installed - show setup wizard with callback to re-bootstrap
-    // NOTE: We intentionally mount only the providers needed for updates + theme.
-    // We cannot mount AppProviders here because GlobalEventsProvider will try to start OpenCode.
     root.render(
       <React.StrictMode>
-        <ThemeProvider defaultTheme="dark" storageKey="dilag-theme">
-          <UpdaterProvider>
-            <CheckUpdatesMenuListener />
-            <SetupWizard onComplete={() => bootstrap()} />
-            <Toaster />
-          </UpdaterProvider>
-        </ThemeProvider>
+        <RouterProvider router={router} />
       </React.StrictMode>,
     )
+    return
   } catch (error) {
-    // Check failed - show setup wizard (safer to assume not installed)
-    console.error("Failed to check OpenCode installation:", error)
+    console.error("Failed to start Pi runtime:", error)
     root.render(
       <React.StrictMode>
         <ThemeProvider defaultTheme="dark" storageKey="dilag-theme">

--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -28,6 +28,7 @@ const desktopBridgeMock: DesktopBridge = {
     getProviderData: vi.fn(),
     listProviders: vi.fn(),
     setApiKey: vi.fn(),
+    loginOAuthProvider: vi.fn(),
     createSession: vi.fn(),
     getSession: vi.fn(),
     getMessages: vi.fn(),

--- a/packages/desktop-bridge/src/index.ts
+++ b/packages/desktop-bridge/src/index.ts
@@ -14,6 +14,7 @@ import type {
   AgentQuestionRequest,
   AgentRuntimeInfo,
   AgentSessionInfo,
+  AgentThinkingLevel,
   AgentTreeNode,
   DesignFile,
   FileNode,
@@ -52,6 +53,7 @@ export interface DesktopBridge {
     getProviderData(): Promise<AgentProviderData>
     listProviders(): Promise<AgentProvider[]>
     setApiKey(args: { providerID: string; apiKey: string }): Promise<void>
+    loginOAuthProvider(args: { providerID: string }): Promise<void>
     createSession(args: { directory: string }): Promise<AgentSessionInfo>
     getSession(args: { sessionID: string; directory: string }): Promise<AgentSessionInfo>
     getMessages(args: { sessionID: string; directory: string }): Promise<AgentMessage[]>
@@ -61,6 +63,7 @@ export interface DesktopBridge {
       text: string
       images?: AgentImageContent[]
       model?: { providerID: string; modelID: string } | null
+      thinkingLevel?: AgentThinkingLevel
     }): Promise<void>
     abort(args: { sessionID: string }): Promise<void>
     renameSession(args: { sessionID: string; name: string }): Promise<void>
@@ -172,6 +175,7 @@ export type {
   AgentQuestionRequest,
   AgentRuntimeInfo,
   AgentSessionInfo,
+  AgentThinkingLevel,
   AgentTreeNode,
   DesignFile,
   FileNode,

--- a/packages/desktop-bridge/src/types.ts
+++ b/packages/desktop-bridge/src/types.ts
@@ -80,6 +80,8 @@ export interface AgentRuntimeInfo {
   sessionCount: number
 }
 
+export type AgentThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh"
+
 export interface AgentModel {
   id: string
   name: string
@@ -90,7 +92,7 @@ export interface AgentModel {
   cost?: { input?: number; output?: number }
   contextWindow?: number
   maxTokens?: number
-  variants?: Record<string, Record<string, unknown>>
+  variants?: Record<AgentThinkingLevel, Record<string, unknown>>
 }
 
 export interface AgentProviderData {
@@ -99,11 +101,14 @@ export interface AgentProviderData {
   defaultModel: { providerID: string; modelID: string } | null
 }
 
+export type AgentProviderAuthType = "api-key" | "oauth"
+
 export interface AgentProvider {
   id: string
   name: string
   connected: boolean
   modelCount: number
+  authType: AgentProviderAuthType
 }
 
 export interface AgentImageContent {


### PR DESCRIPTION
## Summary

Connects Dilag provider authentication and model selection UI to the embedded Pi runtime.

## Changes

- Wire provider data, OAuth/API key flows, and model refresh through bridge.agent
- Update model selector/setup flows for Pi provider state
- Add tests for model selector behavior

## Testing

- bun run fmt:check
- bun run typecheck
- bun run test
- bun run lint
- bun run build
- stack sync --dry-run