### PR TITLE
feat(desktop): route chats through pi sessions

### DIFF
--- a/apps/desktop/electron/ipc/pi.ts
+++ b/apps/desktop/electron/ipc/pi.ts
@@ -28,7 +28,7 @@ import { getPiAgentDir, resolveDesignAssetDir } from "./paths.js"
 type EventSender = (channel: string, event: unknown) => void
 
 type PiTextContent = { type: "text"; text: string }
-type PiThinkingContent = { type: "thinking"; text: string }
+type PiThinkingContent = { type: "thinking"; text?: string; thinking?: string }
 type PiImageContent = { type: "image"; data: string; mimeType: string }
 type PiToolCall = { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }
 type PiContent = string | Array<PiTextContent | PiThinkingContent | PiImageContent | PiToolCall>
@@ -52,6 +52,7 @@ type RuntimeSession = {
   cwd: string
   session: AgentSession
   unsubscribe: () => void
+  activeMessageId?: string
   toolInputs: Map<string, unknown>
   changedFiles: Map<string, { file: string; additions: number; deletions: number }>
 }
@@ -718,20 +719,20 @@ function handlePiSessionEvent(runtime: RuntimeSession, event: AgentSessionEvent)
     event.type === "message_update" ||
     event.type === "message_end"
   ) {
-    emitMessage(runtime.id, event.message as PiMessage, event.type === "message_end")
+    emitMessage(runtime, event.message as PiMessage, event.type === "message_end")
     return
   }
 
   if (event.type === "tool_execution_start") {
     runtime.toolInputs.set(event.toolCallId, event.args)
-    emitToolPart(runtime.id, event.toolCallId, event.toolName, "running", event.args)
+    emitToolPart(runtime, event.toolCallId, event.toolName, "running", event.args)
     return
   }
 
   if (event.type === "tool_execution_update") {
     if (event.args !== undefined) runtime.toolInputs.set(event.toolCallId, event.args)
     emitToolPart(
-      runtime.id,
+      runtime,
       event.toolCallId,
       event.toolName,
       "running",
@@ -744,7 +745,7 @@ function handlePiSessionEvent(runtime: RuntimeSession, event: AgentSessionEvent)
   if (event.type === "tool_execution_end") {
     const input = runtime.toolInputs.get(event.toolCallId)
     emitToolPart(
-      runtime.id,
+      runtime,
       event.toolCallId,
       event.toolName,
       event.isError ? "error" : "completed",
@@ -759,6 +760,7 @@ function handlePiSessionEvent(runtime: RuntimeSession, event: AgentSessionEvent)
   }
 
   if (event.type === "agent_end") {
+    runtime.activeMessageId = undefined
     emitSessionIdle(runtime.id)
     return
   }
@@ -771,10 +773,15 @@ function handlePiSessionEvent(runtime: RuntimeSession, event: AgentSessionEvent)
   }
 }
 
-function emitMessage(sessionID: string, message: PiMessage, completed: boolean) {
+function emitMessage(runtime: RuntimeSession, message: PiMessage, completed: boolean) {
   if (message.role !== "user" && message.role !== "assistant") return
 
-  const messageID = messageId(sessionID, message)
+  const sessionID = runtime.id
+  const messageID =
+    message.role === "assistant"
+      ? (runtime.activeMessageId ?? messageId(sessionID, message))
+      : messageId(sessionID, message)
+  if (message.role === "assistant") runtime.activeMessageId = messageID
   const created = message.timestamp ?? Date.now()
   emitAgentEvent({
     type: "message.updated",
@@ -797,14 +804,16 @@ function emitMessage(sessionID: string, message: PiMessage, completed: boolean) 
 }
 
 function emitToolPart(
-  sessionID: string,
+  runtime: RuntimeSession,
   toolCallId: string,
   toolName: string,
   status: "running" | "completed" | "error",
   input?: unknown,
   output?: unknown,
 ) {
-  const messageID = `${sessionID}:assistant:active`
+  const sessionID = runtime.id
+  const messageID = runtime.activeMessageId ?? `${sessionID}:assistant:active`
+  runtime.activeMessageId = messageID
   emitAgentEvent({
     type: "message.updated",
     properties: {
@@ -828,8 +837,9 @@ function emitToolPart(
         state: {
           status,
           input,
-          output: output === undefined ? undefined : stringifyResult(output),
-          error: status === "error" ? stringifyResult(output) : undefined,
+          output: output === undefined ? undefined : toolResultText(output),
+          error: status === "error" ? toolResultText(output) : undefined,
+          metadata: toolResultMetadata(toolName, output),
           time: { start: Date.now(), end: status === "running" ? undefined : Date.now() },
         },
       },
@@ -870,7 +880,7 @@ function messageParts(
       return [{ id, messageID, sessionID, type: "text", text: part.text }]
     }
     if (part.type === "thinking") {
-      return [{ id, messageID, sessionID, type: "reasoning", text: part.text }]
+      return [{ id, messageID, sessionID, type: "reasoning", text: part.text ?? part.thinking }]
     }
     if (part.type === "image") {
       return [
@@ -953,13 +963,43 @@ function messageText(message: PiMessage | undefined): string | undefined {
     .join("\n")
 }
 
-function stringifyResult(value: unknown): string {
+function toolResultText(value: unknown): string {
   if (typeof value === "string") return value
+  if (isToolResultWithContent(value)) {
+    return value.content
+      .map((part) => {
+        if (part.type === "text") return part.text
+        if (part.type === "image") return `[Image: ${part.mimeType}]`
+        return ""
+      })
+      .filter(Boolean)
+      .join("\n")
+  }
   try {
     return JSON.stringify(value, null, 2)
   } catch {
     return String(value)
   }
+}
+
+function toolResultMetadata(toolName: string, value: unknown): Record<string, unknown> | undefined {
+  if (!isToolResultWithContent(value)) return undefined
+  const text = toolResultText(value)
+  return {
+    ...(typeof value.details === "object" && value.details ? value.details : {}),
+    preview: toolName === "read" ? text.split("\n").slice(0, 40).join("\n") : undefined,
+  }
+}
+
+function isToolResultWithContent(value: unknown): value is {
+  content: Array<PiTextContent | PiImageContent>
+  details?: unknown
+} {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Array.isArray((value as { content?: unknown }).content)
+  )
 }
 
 function humanizeProviderName(id: string): string {

--- a/apps/desktop/src/components/blocks/chat/chat-view.tsx
+++ b/apps/desktop/src/components/blocks/chat/chat-view.tsx
@@ -26,15 +26,12 @@ import {
 import { usePendingMessage } from "@/hooks/use-chat-interface"
 import { DilagIcon } from "@/components/blocks/branding/dilag-icon"
 import { useSessions } from "@/hooks/use-sessions"
-import { useSDK } from "@/context/global-events"
 import {
   useMessageParts,
   useSessionError,
   useSessionRevert,
   useSessionStore,
-  usePendingPermissions,
   usePendingQuestions,
-  useRunningPermissionTools,
   useRunningQuestionTools,
   type Message as SessionMessage,
 } from "@/context/session-store"
@@ -74,12 +71,12 @@ import { AgentSelectorButton } from "@/components/blocks/selectors/agent-selecto
 import { ThinkingModeSelector } from "@/components/blocks/selectors/thinking-mode-selector"
 import { TimelineDialog } from "@/components/blocks/dialogs/dialog-timeline"
 import { RevertBanner } from "./revert-banner"
-import { PermissionList } from "./permission-list"
 import { QuestionList } from "./question-list"
-import { StuckToolWarning } from "@/components/blocks/errors/stuck-tool-warning"
 import { AttachmentBridgeConnector } from "./attachment-bridge-connector"
 import type { MessagePart as MessagePartType } from "@/context/session-store"
+import type { FileNode } from "@dilag/desktop-bridge"
 import { toast } from "sonner"
+import { bridge } from "@/lib/bridge"
 
 const FILE_MENTION_SEARCH_DEBOUNCE_MS = 150
 const FILE_MENTION_SEARCH_LIMIT = 20
@@ -111,6 +108,19 @@ type MentionFileContent = {
 
 function getFileDisplayName(path: string): string {
   return path.split(/[\\/]/).pop() || path
+}
+
+function flattenFileNodes(nodes: FileNode[]): string[] {
+  const files: string[] = []
+  const visit = (node: FileNode) => {
+    if (node.isDir) {
+      node.children?.forEach(visit)
+      return
+    }
+    files.push(node.id)
+  }
+  nodes.forEach(visit)
+  return files
 }
 
 // Detect active @file mention at a given caret position.
@@ -216,27 +226,6 @@ const BUSY_FALLBACKS = [
   "Planning",
   "Cooking",
 ] as const
-
-function formatToolActivity(tool: string): string {
-  switch (tool) {
-    case "bash":
-      return "Running command"
-    case "read":
-    case "glob":
-    case "grep":
-      return "Searching project"
-    case "edit":
-    case "write":
-      return "Editing files"
-    case "webfetch":
-    case "websearch":
-      return "Browsing"
-    case "task":
-      return "Working"
-    default:
-      return `Running ${tool}`
-  }
-}
 
 function useBusyFallbackOnce(active: boolean): string {
   const [label, setLabel] = useState<string>(BUSY_FALLBACKS[0])
@@ -499,7 +488,12 @@ function AssistantMessage({
 }) {
   const parts = useMessageParts(message.id)
   const sessionError = useSessionError(message.sessionID)
-  const renderableParts = parts.filter(wouldRenderContent)
+  const nonReasoningParts = parts.filter((part) => part.type !== "reasoning" && wouldRenderContent(part))
+  const renderableParts = nonReasoningParts.length > 0 ? parts.filter(wouldRenderContent) : []
+
+  if (!message.isStreaming && renderableParts.length === 0 && !sessionError) {
+    return null
+  }
 
   return (
     <Message
@@ -594,7 +588,7 @@ function LoadingState() {
         </div>
         <div className="text-center space-y-1">
           <p className="text-sm font-medium">Starting server</p>
-          <p className="text-xs text-muted-foreground">Initializing OpenCode...</p>
+          <p className="text-xs text-muted-foreground">Initializing Pi...</p>
         </div>
       </div>
     </div>
@@ -614,7 +608,7 @@ function ErrorState({ error }: { error: string }) {
           <div className="space-y-2">
             <h3 className="text-sm font-medium text-destructive">{error}</h3>
             <p className="text-xs text-muted-foreground">
-              Make sure OpenCode is installed and configured correctly.
+              Make sure Pi has an authenticated model provider configured.
             </p>
           </div>
         </div>
@@ -634,7 +628,6 @@ function ChatInputArea({
   stopSession: () => Promise<void>
   sessionCwd: string | null
 }) {
-  const sdk = useSDK()
   const composerTextareaId = useId()
   const { textInput, attachments, screenRefs } = usePromptInputController()
   const [caretPosition, setCaretPosition] = useState(0)
@@ -694,19 +687,18 @@ function ChatInputArea({
 
     const timer = window.setTimeout(async () => {
       try {
-        const response = await sdk.find.files({
-          directory: sessionCwd,
-          query: activeMention.query,
-          type: "file",
-          limit: FILE_MENTION_SEARCH_LIMIT,
-        })
+        const files = flattenFileNodes(await bridge.project.listFiles({ sessionCwd }))
+        const query = activeMention.query.trim().toLowerCase()
 
         if (requestId !== mentionSearchRequestRef.current) return
 
-        const results = (response.data ?? []).map((path) => ({
-          path,
-          displayName: getFileDisplayName(path),
-        }))
+        const results = files
+          .filter((path) => !query || path.toLowerCase().includes(query))
+          .slice(0, FILE_MENTION_SEARCH_LIMIT)
+          .map((path) => ({
+            path,
+            displayName: getFileDisplayName(path),
+          }))
         setMentionSearchResults(results)
         setHighlightedMentionIndex(0)
       } catch {
@@ -720,7 +712,7 @@ function ChatInputArea({
     }, FILE_MENTION_SEARCH_DEBOUNCE_MS)
 
     return () => window.clearTimeout(timer)
-  }, [activeMention, mentionOpen, sdk, sessionCwd])
+  }, [activeMention, mentionOpen, sessionCwd])
 
   const syncCaretPosition = useCallback((target: HTMLTextAreaElement | null) => {
     if (!target) return
@@ -827,14 +819,14 @@ function ChatInputArea({
 
     for (const file of mentionedFiles) {
       try {
-        const response = await sdk.file.read({
-          directory: sessionCwd ?? undefined,
-          path: file.path,
-        })
-        const content = response.data as MentionFileContent | undefined
-        if (!content || typeof content.content !== "string") {
+        if (!sessionCwd) {
           failedCount++
           continue
+        }
+        const fileContent = await bridge.project.readFile({ sessionCwd, filePath: file.path })
+        const content: MentionFileContent = {
+          content: fileContent,
+          mimeType: "text/plain",
         }
 
         const bytes = estimateMentionFileSizeBytes(content.content, content.encoding)
@@ -856,7 +848,7 @@ function ChatInputArea({
     }
 
     return { parts, tooLargeCount, failedCount }
-  }, [mentionedFiles, sdk, sessionCwd])
+  }, [mentionedFiles, sessionCwd])
 
   const handleSubmit = async (text: string, files?: import("ai").FileUIPart[]) => {
     if (isLoading) return
@@ -1194,9 +1186,7 @@ export function ChatView() {
   }, [messages])
 
   // Activity cues (derived from available session events/state)
-  const pendingPermissions = usePendingPermissions(currentSessionId)
   const pendingQuestions = usePendingQuestions(currentSessionId)
-  const runningPermissionTools = useRunningPermissionTools(currentSessionId)
   const runningQuestionTools = useRunningQuestionTools(currentSessionId)
   const busyFallbackOnce = useBusyFallbackOnce(isLoading)
 
@@ -1205,15 +1195,6 @@ export function ChatView() {
 
     if (pendingQuestions.length > 0) {
       return "Waiting for your answer"
-    }
-
-    if (pendingPermissions.length > 0) {
-      return "Waiting for permission"
-    }
-
-    if (runningPermissionTools.length > 0) {
-      const oldest = [...runningPermissionTools].sort((a, b) => a.startTime - b.startTime)[0]
-      return formatToolActivity(oldest.tool)
     }
 
     if (runningQuestionTools.length > 0) {
@@ -1228,8 +1209,6 @@ export function ChatView() {
   }, [
     isLoading,
     pendingQuestions.length,
-    pendingPermissions.length,
-    runningPermissionTools,
     runningQuestionTools.length,
     sessionStatus,
     busyFallbackOnce,
@@ -1333,12 +1312,6 @@ export function ChatView() {
         <div className="shrink-0">
           {/* Question prompts - shown when AI is asking questions */}
           <QuestionList className="px-4 pb-2" />
-
-          {/* Warning for stuck question tools */}
-          <StuckToolWarning className="mx-4 mb-2" />
-
-          {/* Permission prompts - shown when permissions are pending */}
-          <PermissionList className="px-4 pb-2" />
 
           <ChatInputArea
             isLoading={isLoading}

--- a/apps/desktop/src/components/blocks/chat/chat-view.tsx
+++ b/apps/desktop/src/components/blocks/chat/chat-view.tsx
@@ -488,7 +488,9 @@ function AssistantMessage({
 }) {
   const parts = useMessageParts(message.id)
   const sessionError = useSessionError(message.sessionID)
-  const nonReasoningParts = parts.filter((part) => part.type !== "reasoning" && wouldRenderContent(part))
+  const nonReasoningParts = parts.filter(
+    (part) => part.type !== "reasoning" && wouldRenderContent(part),
+  )
   const renderableParts = nonReasoningParts.length > 0 ? parts.filter(wouldRenderContent) : []
 
   if (!message.isStreaming && renderableParts.length === 0 && !sessionError) {

--- a/apps/desktop/src/components/blocks/chat/permission-list.tsx
+++ b/apps/desktop/src/components/blocks/chat/permission-list.tsx
@@ -1,93 +1,11 @@
-import { useCallback } from "react"
-import {
-  usePendingPermissions,
-  useCurrentSessionId,
-  useSessionStore,
-  type PermissionRequest,
-} from "@/context/session-store"
-import { useSDK } from "@/context/global-events"
-import { PermissionPrompt, type PermissionReply } from "@/components/ai-elements/permission-prompt"
-import { cn } from "@/lib/utils"
-import { useSessionsList } from "@/hooks/use-session-data"
-
-// Timeout for permission reply requests (30 seconds)
-const PERMISSION_REPLY_TIMEOUT = 30000
-
 interface PermissionListProps {
   sessionId?: string
   className?: string
 }
 
-export function PermissionList({ sessionId, className }: PermissionListProps) {
-  const currentSessionId = useCurrentSessionId()
-  const effectiveSessionId = sessionId ?? currentSessionId
-  const pendingPermissions = usePendingPermissions(effectiveSessionId)
-  const sdk = useSDK()
-  const { data: sessions = [] } = useSessionsList()
-
-  // Get the session's directory (cwd) for API calls
-  const getSessionDirectory = useCallback(
-    (sessionID: string): string | undefined => {
-      const session = sessions.find((s) => s.id === sessionID)
-      return session?.cwd
-    },
-    [sessions],
-  )
-
-  const handleReply = useCallback(
-    async (request: PermissionRequest, reply: PermissionReply, message?: string) => {
-      const directory = getSessionDirectory(request.sessionID)
-      try {
-        // Create a timeout promise
-        const timeoutPromise = new Promise<never>((_, reject) => {
-          setTimeout(() => reject(new Error("Permission reply timeout")), PERMISSION_REPLY_TIMEOUT)
-        })
-
-        // Race between the actual reply and timeout
-        await Promise.race([
-          sdk.permission.reply({
-            requestID: request.id,
-            directory,
-            reply,
-            message,
-          }),
-          timeoutPromise,
-        ])
-
-        // Success! Remove permission immediately instead of waiting for event
-        // This prevents the UI from being stuck if the permission.replied event is lost
-        if (effectiveSessionId) {
-          useSessionStore.getState().removePendingPermission(effectiveSessionId, request.id)
-          console.log("[PermissionList] Permission reply successful, removed from store")
-        }
-      } catch (err) {
-        console.error("[PermissionList] Failed to reply to permission:", err)
-        // Permission likely doesn't exist in backend anymore (stale state)
-        // Or the request timed out
-        // Remove it from the store to clean up the UI
-        if (effectiveSessionId) {
-          useSessionStore.getState().removePendingPermission(effectiveSessionId, request.id)
-          // Also abort any running tools since the permission was lost
-          useSessionStore.getState().abortRunningTools(effectiveSessionId)
-        }
-      }
-    },
-    [sdk, effectiveSessionId, getSessionDirectory],
-  )
-
-  if (!effectiveSessionId || pendingPermissions.length === 0) {
-    return null
-  }
-
-  return (
-    <div className={cn("space-y-2", className)}>
-      {pendingPermissions.map((request) => (
-        <PermissionPrompt
-          key={request.id}
-          request={request}
-          onReply={(reply, message) => handleReply(request, reply, message)}
-        />
-      ))}
-    </div>
-  )
+// Pi is embedded with Dilag-owned tools, so the old permission approval surface
+// is intentionally retired. Keep this component as a harmless shim for any stale
+// imports while the chat layout finishes migrating.
+export function PermissionList(_props: PermissionListProps) {
+  return null
 }

--- a/apps/desktop/src/components/blocks/chat/question-list.tsx
+++ b/apps/desktop/src/components/blocks/chat/question-list.tsx
@@ -7,8 +7,7 @@ import {
 } from "@/context/session-store"
 import { QuestionPrompt } from "@/components/ai-elements/question-prompt"
 import { cn } from "@/lib/utils"
-import { useSessionsList } from "@/hooks/use-session-data"
-import { useSDK } from "@/context/global-events"
+import { bridge } from "@/lib/bridge"
 
 // Timeout for question reply requests (30 seconds)
 const QUESTION_REPLY_TIMEOUT = 30000
@@ -19,25 +18,13 @@ interface QuestionListProps {
 }
 
 export function QuestionList({ sessionId, className }: QuestionListProps) {
-  const sdk = useSDK()
   const currentSessionId = useCurrentSessionId()
   const effectiveSessionId = sessionId ?? currentSessionId
   const pendingQuestions = usePendingQuestions(effectiveSessionId)
   const removePendingQuestion = useSessionStore((s) => s.removePendingQuestion)
-  const { data: sessions = [] } = useSessionsList()
-
-  // Get the session's directory (cwd) for API calls
-  const getSessionDirectory = useCallback(
-    (sessionID: string): string | undefined => {
-      const session = sessions.find((s) => s.id === sessionID)
-      return session?.cwd
-    },
-    [sessions],
-  )
 
   const handleReply = useCallback(
     async (request: QuestionRequest, answers: string[][]) => {
-      const directory = getSessionDirectory(request.sessionID)
       try {
         // Create a timeout promise
         const timeoutPromise = new Promise<never>((_, reject) => {
@@ -45,24 +32,17 @@ export function QuestionList({ sessionId, className }: QuestionListProps) {
         })
 
         // Race between the actual reply and timeout
-        const response = await Promise.race([
-          sdk.question.reply({
+        await Promise.race([
+          bridge.agent.replyQuestion({
             requestID: request.id,
-            directory,
             answers,
           }),
           timeoutPromise,
         ])
 
-        if (response.data !== undefined && effectiveSessionId) {
+        if (effectiveSessionId) {
           removePendingQuestion(effectiveSessionId, request.id)
           console.log("[QuestionList] Question reply successful, removed from store")
-        } else {
-          console.error("[QuestionList] Failed to reply:", response.error)
-          // Still remove on error to prevent stuck state
-          if (effectiveSessionId) {
-            removePendingQuestion(effectiveSessionId, request.id)
-          }
         }
       } catch (err) {
         console.error("[QuestionList] Failed to reply:", err)
@@ -73,12 +53,11 @@ export function QuestionList({ sessionId, className }: QuestionListProps) {
         }
       }
     },
-    [effectiveSessionId, removePendingQuestion, getSessionDirectory, sdk],
+    [effectiveSessionId, removePendingQuestion],
   )
 
   const handleReject = useCallback(
     async (request: QuestionRequest) => {
-      const directory = getSessionDirectory(request.sessionID)
       try {
         // Create a timeout promise
         const timeoutPromise = new Promise<never>((_, reject) => {
@@ -86,23 +65,16 @@ export function QuestionList({ sessionId, className }: QuestionListProps) {
         })
 
         // Race between the actual reject and timeout
-        const response = await Promise.race([
-          sdk.question.reject({
+        await Promise.race([
+          bridge.agent.rejectQuestion({
             requestID: request.id,
-            directory,
           }),
           timeoutPromise,
         ])
 
-        if (response.data !== undefined && effectiveSessionId) {
+        if (effectiveSessionId) {
           removePendingQuestion(effectiveSessionId, request.id)
           console.log("[QuestionList] Question reject successful, removed from store")
-        } else {
-          console.error("[QuestionList] Failed to reject:", response.error)
-          // Still remove on error to prevent stuck state
-          if (effectiveSessionId) {
-            removePendingQuestion(effectiveSessionId, request.id)
-          }
         }
       } catch (err) {
         console.error("[QuestionList] Failed to reject:", err)
@@ -113,7 +85,7 @@ export function QuestionList({ sessionId, className }: QuestionListProps) {
         }
       }
     },
-    [effectiveSessionId, removePendingQuestion, getSessionDirectory, sdk],
+    [effectiveSessionId, removePendingQuestion],
   )
 
   if (!effectiveSessionId || pendingQuestions.length === 0) {

--- a/apps/desktop/src/context/global-events.tsx
+++ b/apps/desktop/src/context/global-events.tsx
@@ -1,51 +1,35 @@
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useRef,
   useState,
-  useCallback,
   type ReactNode,
 } from "react"
-import { createOpencodeClient, type Event, type OpencodeClient } from "@opencode-ai/sdk/v2/client"
-import { extractSessionId } from "@/lib/event-guards"
+import { extractSessionId, type Event } from "@/lib/event-guards"
 import { useSessionStore } from "@/context/session-store"
 import { bridge } from "@/lib/bridge"
 
-export type { Event } from "@opencode-ai/sdk/v2/client"
 export type {
+  Event,
   EventMessagePartUpdated,
   EventMessageUpdated,
   EventSessionStatus,
-  EventSessionUpdated,
+  EventSessionUpdatedCustom as EventSessionUpdated,
   EventSessionDiff,
   EventSessionIdle,
   EventSessionError,
-  SessionStatus,
   Part,
   ToolState,
   SnapshotFileDiff as FileDiff,
-} from "@opencode-ai/sdk/v2/client"
-
-function getOpenCodePort(): number {
-  return bridge.bootstrap.port || 4096
-}
-
-// SSE Reconnection Configuration
-const SSE_CONFIG = {
-  defaultRetryDelay: 3000, // 3 seconds initial delay
-  maxRetryDelay: 30000, // 30 seconds max delay
-  maxRetryAttempts: undefined, // Unlimited retries by default
-  backoffFactor: 2, // Double delay each attempt
-}
+} from "@/lib/event-guards"
 
 type EventHandler = (event: Event) => void
 
-// Connection status type
 export type ConnectionStatus = "disconnected" | "connecting" | "connected" | "reconnecting"
 
 interface GlobalEventsContextValue {
-  sdk: OpencodeClient
   subscribe: (handler: EventHandler) => () => void
   subscribeToSession: (sessionId: string, handler: EventHandler) => () => void
   connectionStatus: ConnectionStatus
@@ -62,39 +46,17 @@ export function GlobalEventsProvider({ children }: { children: ReactNode }) {
   const [isServerReady, setIsServerReady] = useState(false)
   const [serverError, setServerError] = useState<string | null>(null)
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>("disconnected")
-  const [reconnectAttempt, setReconnectAttempt] = useState(0)
+  const [reconnectAttempt] = useState(0)
   const handlersRef = useRef<Set<EventHandler>>(new Set())
   const sessionHandlersRef = useRef<Map<string, Set<EventHandler>>>(new Map())
-  const abortControllerRef = useRef<AbortController | null>(null)
   const mountedRef = useRef(true)
   const bootstrapCallbacksRef = useRef<Set<() => void>>(new Set())
 
-  const sdkRef = useRef<OpencodeClient | null>(null)
-  if (!sdkRef.current) {
-    const port = getOpenCodePort()
-    const customFetch = (input: RequestInfo | URL, init?: RequestInit) => {
-      if (init && typeof input === "string" && input.includes("/event")) {
-        // @ts-expect-error - timeout is a non-standard property
-        if (init) init.timeout = false
-      }
-      return fetch(input, init)
-    }
-
-    sdkRef.current = createOpencodeClient({
-      baseUrl: `http://127.0.0.1:${port}`,
-      fetch: customFetch,
-    })
-    console.log("[GlobalEvents] SDK created with port:", port)
-  }
-  const sdk = sdkRef.current
-
-  // Subscribe to all events
   const subscribe = useCallback((handler: EventHandler): (() => void) => {
     handlersRef.current.add(handler)
     return () => handlersRef.current.delete(handler)
   }, [])
 
-  // Subscribe to events for a specific session
   const subscribeToSession = useCallback(
     (sessionId: string, handler: EventHandler): (() => void) => {
       if (!sessionHandlersRef.current.has(sessionId)) {
@@ -113,191 +75,69 @@ export function GlobalEventsProvider({ children }: { children: ReactNode }) {
     [],
   )
 
-  // Calculate retry delay with exponential backoff
-  const calculateRetryDelay = (attempt: number, serverRetryDelay?: number): number => {
-    // If server provided a retry delay, use it
-    if (serverRetryDelay !== undefined) {
-      return serverRetryDelay
-    }
-    // Otherwise use exponential backoff
-    const delay = SSE_CONFIG.defaultRetryDelay * Math.pow(SSE_CONFIG.backoffFactor, attempt - 1)
-    return Math.min(delay, SSE_CONFIG.maxRetryDelay)
-  }
-
-  // Bootstrap function to reload all state after reconnection
   const bootstrap = useCallback(async () => {
-    console.log("[GlobalEvents] Running bootstrap - syncing pending permissions and questions")
-
-    // Sync pending permissions from server.
-    // SDK v1.4 returns either `{ data }` or `{ data, response }` depending on the call path —
-    // guard both shapes.
-    try {
-      const result = (await sdk.permission.list()) as {
-        data?: unknown
-        response?: { ok: boolean }
-      }
-      const ok = result.response ? result.response.ok : true
-      if (ok && Array.isArray(result.data)) {
-        const permissions =
-          result.data as unknown as import("@/lib/event-guards").PermissionRequest[]
-        useSessionStore.getState().syncPendingPermissions(permissions)
-        console.log("[GlobalEvents] Synced", permissions.length, "pending permissions")
-      }
-    } catch (err) {
-      console.error("[GlobalEvents] Failed to sync permissions:", err)
-    }
+    console.log("[GlobalEvents] Running bootstrap - syncing pending questions")
 
     try {
-      const result = (await sdk.question.list()) as {
-        data?: unknown
-        response?: { ok: boolean }
-      }
-      const ok = result.response ? result.response.ok : true
-      if (ok && Array.isArray(result.data)) {
-        const questions = result.data as unknown as import("@/lib/event-guards").QuestionRequest[]
-        useSessionStore.getState().syncPendingQuestions(questions)
-        console.log("[GlobalEvents] Synced", questions.length, "pending questions")
-      }
+      const questions = await bridge.agent.listQuestions()
+      useSessionStore
+        .getState()
+        .syncPendingQuestions(questions as import("@/lib/event-guards").QuestionRequest[])
+      console.log("[GlobalEvents] Synced", questions.length, "pending questions")
     } catch (err) {
       console.error("[GlobalEvents] Failed to sync questions:", err)
     }
 
-    // Notify all registered bootstrap callbacks
     bootstrapCallbacksRef.current.forEach((callback) => callback())
-  }, [sdk])
+  }, [])
 
-  // Handle disposal events that require re-bootstrap
-  const handleDisposalEvent = useCallback(
-    (event: Event) => {
-      if (event.type === "global.disposed") {
-        console.log("[GlobalEvents] Global disposed - running full bootstrap")
-        bootstrap()
-      } else if (event.type === "server.instance.disposed") {
-        console.log("[GlobalEvents] Server instance disposed - running bootstrap")
-        bootstrap()
-      }
-    },
-    [bootstrap],
-  )
+  useEffect(() => {
+    mountedRef.current = true
+    let unsubscribe: (() => void) | undefined
 
-  // Connect to SSE with reconnection logic
-  const connectToSSE = useCallback(async () => {
-    let attempt = 0
-    let serverRetryDelay: number | undefined
-
-    while (mountedRef.current) {
-      // Check max retry attempts
-      if (SSE_CONFIG.maxRetryAttempts !== undefined && attempt >= SSE_CONFIG.maxRetryAttempts) {
-        console.log("[GlobalEvents] Max retry attempts reached, giving up")
-        setConnectionStatus("disconnected")
-        break
-      }
-
-      attempt++
-      setReconnectAttempt(attempt)
-
-      if (attempt === 1) {
-        setConnectionStatus("connecting")
-      } else {
-        setConnectionStatus("reconnecting")
-        console.log(`[GlobalEvents] Reconnection attempt ${attempt}...`)
-      }
+    async function init() {
+      console.log("[GlobalEvents] Starting agent runtime...")
+      setConnectionStatus("connecting")
 
       try {
-        console.log("[GlobalEvents] Connecting to event stream...")
-        const events = await sdk.global.event()
+        await bridge.agent.start()
+        console.log("[GlobalEvents] Agent runtime started")
 
-        if (!mountedRef.current) break
-
-        // Reset attempt counter on successful connection
-        attempt = 0
-        setReconnectAttempt(0)
+        if (!mountedRef.current) return
         setConnectionStatus("connected")
-        console.log("[GlobalEvents] Connected to event stream")
+        setIsServerReady(true)
+        setServerError(null)
 
-        // Run bootstrap to sync pending permissions/questions
-        // Always run on reconnection, optionally on first connection too
         await bootstrap()
 
-        // Process events
-        for await (const event of events.stream) {
-          if (!mountedRef.current) break
+        unsubscribe = bridge.agent.onEvent((payload) => {
+          const event = payload as Event
+          if (!mountedRef.current) return
 
-          const payload = event.payload
-
-          handleDisposalEvent(payload)
-          useSessionStore.getState().handleEvent(payload)
+          useSessionStore.getState().handleEvent(event)
 
           handlersRef.current.forEach((handler) => {
             try {
-              handler(payload)
+              handler(event)
             } catch (err) {
               console.error("[GlobalEvents] Handler error:", err)
             }
           })
 
-          // Notify session-specific handlers
-          const sessionId = extractSessionId(payload)
+          const sessionId = extractSessionId(event)
           if (sessionId) {
             const sessionHandlers = sessionHandlersRef.current.get(sessionId)
             sessionHandlers?.forEach((handler) => {
               try {
-                handler(payload)
+                handler(event)
               } catch (err) {
                 console.error("[GlobalEvents] Session handler error:", err)
               }
             })
           }
-        }
-
-        // Stream ended normally (server closed connection)
-        console.log("[GlobalEvents] Stream ended, will reconnect...")
+        })
       } catch (err) {
-        console.error("[GlobalEvents] Connection error:", err)
-
-        if (!mountedRef.current) break
-        setConnectionStatus("reconnecting")
-      }
-
-      // Calculate and wait for retry delay
-      const delay = calculateRetryDelay(attempt, serverRetryDelay)
-      console.log(`[GlobalEvents] Waiting ${delay}ms before retry...`)
-
-      await new Promise((resolve) => {
-        const timeout = setTimeout(resolve, delay)
-        // Allow abort to cancel the delay
-        if (abortControllerRef.current) {
-          abortControllerRef.current.signal.addEventListener(
-            "abort",
-            () => {
-              clearTimeout(timeout)
-              resolve(undefined)
-            },
-            { once: true },
-          )
-        }
-      })
-    }
-  }, [sdk, bootstrap, handleDisposalEvent])
-
-  // Start server and connect to event stream
-  useEffect(() => {
-    mountedRef.current = true
-    abortControllerRef.current = new AbortController()
-
-    async function init() {
-      console.log("[GlobalEvents] Starting OpenCode server...")
-      try {
-        const port = await bridge.opencode!.start()
-        console.log("[GlobalEvents] Server started on port", port)
-
-        if (!mountedRef.current) return
-        setIsServerReady(true)
-
-        // Start SSE connection with reconnection logic
-        await connectToSSE()
-      } catch (err) {
-        console.error("[GlobalEvents] Server start error:", err)
+        console.error("[GlobalEvents] Agent runtime start error:", err)
         if (mountedRef.current) {
           setIsServerReady(false)
           setServerError(err instanceof Error ? err.message : String(err))
@@ -310,15 +150,14 @@ export function GlobalEventsProvider({ children }: { children: ReactNode }) {
 
     return () => {
       mountedRef.current = false
-      abortControllerRef.current?.abort()
+      unsubscribe?.()
       console.log("[GlobalEvents] Cleanup - disconnected")
     }
-  }, [connectToSSE])
+  }, [bootstrap])
 
   return (
     <GlobalEventsContext.Provider
       value={{
-        sdk,
         subscribe,
         subscribeToSession,
         connectionStatus,
@@ -340,11 +179,6 @@ export function useGlobalEvents() {
     throw new Error("useGlobalEvents must be used within a GlobalEventsProvider")
   }
   return context
-}
-
-export function useSDK() {
-  const { sdk } = useGlobalEvents()
-  return sdk
 }
 
 export function useConnectionStatus() {

--- a/apps/desktop/src/context/session-store.test.ts
+++ b/apps/desktop/src/context/session-store.test.ts
@@ -345,5 +345,37 @@ describe("session-store", () => {
       expect(parts).toHaveLength(1)
       expect(parts[0].text).toBe("Hello")
     })
+
+    it("should handle session.diff events synthesized from agent file writes", () => {
+      const event = {
+        type: "session.diff" as const,
+        properties: {
+          sessionID: "session-1",
+          diff: [{ file: "screens/home.html", additions: 12, deletions: 3 }],
+        },
+      }
+
+      useSessionStore.getState().handleEvent(event as any)
+
+      expect(useSessionStore.getState().sessionDiffs["session-1"]).toEqual([
+        { file: "screens/home.html", additions: 12, deletions: 3 },
+      ])
+    })
+
+    it("should handle file watcher events synthesized from agent file writes", () => {
+      const event = {
+        type: "file.watcher.updated" as const,
+        properties: {
+          file: "screens/home.html",
+          event: "change" as const,
+        },
+      }
+
+      useSessionStore.getState().handleEvent(event as any)
+
+      expect(useSessionStore.getState().recentFileChanges).toMatchObject([
+        { file: "screens/home.html", event: "change" },
+      ])
+    })
   })
 })

--- a/apps/desktop/src/context/session-store.tsx
+++ b/apps/desktop/src/context/session-store.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react"
 import { create } from "zustand"
 import { persist, createJSONStorage } from "zustand/middleware"
 import { immer } from "zustand/middleware/immer"
-import type { Event, SnapshotFileDiff as FileDiff, ToolState } from "@opencode-ai/sdk/v2/client"
 import {
   isEventMessagePartUpdated,
   isEventMessageUpdated,
@@ -26,6 +25,9 @@ import {
   type EventQuestionAsked,
   type EventQuestionReplied,
   type EventQuestionRejected,
+  type Event,
+  type SnapshotFileDiff as FileDiff,
+  type ToolState,
 } from "@/lib/event-guards"
 
 // Re-export types for consumers
@@ -49,7 +51,7 @@ export interface SessionMeta {
   id: string
   name: string
   created_at: string
-  updated_at?: string // Last activity timestamp (synced from OpenCode SDK)
+  updated_at?: string // Last activity timestamp from the agent runtime
   cwd: string
   parentID?: string // Reference to parent session if forked
   platform?: Platform // "web" (default) or "mobile"
@@ -961,7 +963,7 @@ export function useRunningQuestionTools(sessionId: string | null): RunningQuesti
             partId: part.id,
             callId:
               part.state && "input" in part.state
-                ? (((part.state as Record<string, unknown>).callID as string) ?? part.id)
+                ? (((part.state as unknown as Record<string, unknown>).callID as string) ?? part.id)
                 : part.id,
             startTime: state.time?.start ?? Date.now(),
           })
@@ -1000,7 +1002,7 @@ export function useRunningPermissionTools(sessionId: string | null): RunningPerm
             partId: part.id,
             callId:
               part.state && "input" in part.state
-                ? (((part.state as Record<string, unknown>).callID as string) ?? part.id)
+                ? (((part.state as unknown as Record<string, unknown>).callID as string) ?? part.id)
                 : part.id,
             tool: part.tool,
             startTime: state.time?.start ?? Date.now(),
@@ -1014,7 +1016,7 @@ export function useRunningPermissionTools(sessionId: string | null): RunningPerm
 }
 
 // Hook that returns messages filtered by revert state
-// If session is reverted, only shows messages BEFORE the revert point (matching OpenCode's pattern)
+// If session is reverted, only shows messages before the revert point.
 // The revert messageID is the FIRST message to be hidden
 export function useFilteredSessionMessages(sessionId: string | null) {
   const messages = useSessionStore((state) =>

--- a/apps/desktop/src/hooks/use-agents.ts
+++ b/apps/desktop/src/hooks/use-agents.ts
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
-import { useSDK } from "@/context/global-events"
 import { create } from "zustand"
 import { persist, createJSONStorage } from "zustand/middleware"
 
@@ -69,17 +68,16 @@ function transformAgentData(
  * Hook to fetch agent data
  */
 export function useAgentData() {
-  const sdk = useSDK()
-
   return useQuery({
     queryKey: agentKeys.list(),
-    queryFn: async () => {
-      const response = await sdk.app.agents()
-      if (!response.data) {
-        throw new Error("No agent data received")
-      }
-      return transformAgentData(response.data)
-    },
+    queryFn: async () =>
+      transformAgentData([
+        {
+          name: "build",
+          description: "Dilag design builder",
+          mode: "primary",
+        },
+      ]),
     staleTime: 1000 * 60 * 5, // 5 minutes - agents don't change often
   })
 }

--- a/apps/desktop/src/hooks/use-sessions.test.ts
+++ b/apps/desktop/src/hooks/use-sessions.test.ts
@@ -231,9 +231,7 @@ describe("use-sessions", () => {
 
   describe("tree navigation", () => {
     it("uses Pi tree navigation for timeline revert", async () => {
-      useSessionStore
-        .getState()
-        .setSessionRevert("session-1", { messageID: "stale-message" })
+      useSessionStore.getState().setSessionRevert("session-1", { messageID: "stale-message" })
 
       const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
 

--- a/apps/desktop/src/hooks/use-sessions.test.ts
+++ b/apps/desktop/src/hooks/use-sessions.test.ts
@@ -8,7 +8,6 @@ vi.mock("@/context/global-events", () => ({
     isServerReady: true,
     subscribeToSession: vi.fn(() => () => {}),
   })),
-  useSDK: vi.fn(() => mockSDK),
   useConnectionStatus: vi.fn(() => ({ connectionStatus: "connected" })),
 }))
 
@@ -21,6 +20,7 @@ vi.mock("@/hooks/use-session-data", () => ({
     createSession: vi.fn(),
     updateSession: vi.fn(),
     deleteSession: vi.fn(),
+    toggleFavorite: vi.fn(),
   })),
   createSessionDir: vi.fn(() => Promise.resolve("/mock/session/dir")),
   sessionKeys: {
@@ -42,20 +42,6 @@ vi.mock("@/hooks/use-agents", () => ({
   },
 }))
 
-const mockSDK = {
-  session: {
-    create: vi.fn(() => Promise.resolve({ data: { id: "new-session-id" } })),
-    get: vi.fn(() => Promise.resolve({ data: { id: "session-1", title: "Test Session" } })),
-    messages: vi.fn(() => Promise.resolve({ data: [] })),
-    prompt: vi.fn(() => Promise.resolve({ data: {} })),
-    delete: vi.fn(() => Promise.resolve()),
-    abort: vi.fn(() => Promise.resolve()),
-    fork: vi.fn(() => Promise.resolve({ data: { id: "forked-session-id" } })),
-    revert: vi.fn(() => Promise.resolve({ data: { revert: null } })),
-    unrevert: vi.fn(() => Promise.resolve()),
-  },
-}
-
 const mockSessions = [
   { id: "session-1", name: "Test Session", created_at: "2024-01-01", cwd: "/mock/cwd/1" },
   { id: "session-2", name: "Another Session", created_at: "2024-01-02", cwd: "/mock/cwd/2" },
@@ -65,6 +51,12 @@ import { useSessions } from "./use-sessions"
 import { useSessionStore } from "@/context/session-store"
 import { useModelStore } from "@/hooks/use-models"
 import { useCurrentSession } from "@/hooks/use-session-data"
+
+const mockPrompt = vi.mocked(window.desktopBridge!.agent.prompt)
+const mockAbort = vi.mocked(window.desktopBridge!.agent.abort)
+const mockNavigateTree = vi.mocked(window.desktopBridge!.agent.navigateTree)
+const mockGetSession = vi.mocked(window.desktopBridge!.agent.getSession)
+const mockGetMessages = vi.mocked(window.desktopBridge!.agent.getMessages)
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -78,6 +70,15 @@ function createWrapper() {
 describe("use-sessions", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockPrompt.mockResolvedValue(undefined)
+    mockAbort.mockResolvedValue(undefined)
+    mockNavigateTree.mockResolvedValue({ cancelled: false })
+    mockGetSession.mockResolvedValue({
+      id: "session-1",
+      cwd: "/mock/cwd/1",
+      title: "Test Session",
+    })
+    mockGetMessages.mockResolvedValue([])
 
     useSessionStore.setState({
       currentSessionId: "session-1",
@@ -96,46 +97,23 @@ describe("use-sessions", () => {
   })
 
   describe("sendMessage", () => {
-    it("should use default anthropic model when no model selected", async () => {
+    it("sends prompts through the Pi bridge with the first-run skill hint", async () => {
       const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
 
       await act(async () => {
         await result.current.sendMessage("Hello")
       })
 
-      expect(mockSDK.session.prompt).toHaveBeenCalledWith(
-        expect.objectContaining({
-          model: {
-            providerID: "anthropic",
-            modelID: "claude-sonnet-4-20250514",
-          },
-        }),
-      )
+      expect(mockPrompt).toHaveBeenCalledWith({
+        sessionID: "session-1",
+        directory: "/mock/cwd/1",
+        text: "/skill:web-design Hello",
+        images: [],
+        model: null,
+      })
     })
 
-    it("should use opencode provider when selected", async () => {
-      ;(useModelStore.getState as Mock).mockReturnValue({
-        selectedModel: { providerID: "opencode", modelID: "big-pickle" },
-        variants: {},
-      })
-
-      const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
-
-      await act(async () => {
-        await result.current.sendMessage("Hello")
-      })
-
-      expect(mockSDK.session.prompt).toHaveBeenCalledWith(
-        expect.objectContaining({
-          model: {
-            providerID: "opencode",
-            modelID: "big-pickle",
-          },
-        }),
-      )
-    })
-
-    it("should use selected model when non-opencode provider", async () => {
+    it("uses the selected model when one exists", async () => {
       ;(useModelStore.getState as Mock).mockReturnValue({
         selectedModel: { providerID: "google", modelID: "gemini-2.5-flash" },
         variants: {},
@@ -147,7 +125,7 @@ describe("use-sessions", () => {
         await result.current.sendMessage("Hello")
       })
 
-      expect(mockSDK.session.prompt).toHaveBeenCalledWith(
+      expect(mockPrompt).toHaveBeenCalledWith(
         expect.objectContaining({
           model: {
             providerID: "google",
@@ -157,21 +135,7 @@ describe("use-sessions", () => {
       )
     })
 
-    it("should always use build agent", async () => {
-      const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
-
-      await act(async () => {
-        await result.current.sendMessage("Hello")
-      })
-
-      expect(mockSDK.session.prompt).toHaveBeenCalledWith(
-        expect.objectContaining({
-          agent: "build",
-        }),
-      )
-    })
-
-    it("should not send message when currentSession is null", async () => {
+    it("does not send when currentSession is null", async () => {
       useSessionStore.setState({ currentSessionId: "session-1" })
       ;(useCurrentSession as unknown as Mock).mockReturnValueOnce(null)
 
@@ -181,53 +145,32 @@ describe("use-sessions", () => {
         await result.current.sendMessage("Hello")
       })
 
-      expect(mockSDK.session.prompt).not.toHaveBeenCalled()
+      expect(mockPrompt).not.toHaveBeenCalled()
     })
 
-    it("should not send message when currentSessionId is null", async () => {
-      useSessionStore.setState({ currentSessionId: "non-existent-session" })
-
+    it("passes image attachments through the Pi bridge", async () => {
       const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
 
       await act(async () => {
-        await result.current.sendMessage("Hello")
+        await result.current.sendMessage("Hello with image", [
+          {
+            type: "file",
+            url: "data:image/png;base64,abc",
+            mediaType: "image/png",
+            filename: "test.png",
+          },
+        ])
       })
 
-      expect(mockSDK.session.prompt).not.toHaveBeenCalled()
-    })
-
-    it("should include file parts when files are provided", async () => {
-      const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
-
-      const files = [
-        {
-          type: "file" as const,
-          url: "data:image/png;base64,abc",
-          mediaType: "image/png",
-          filename: "test.png",
-        },
-      ]
-
-      await act(async () => {
-        await result.current.sendMessage("Hello with image", files)
-      })
-
-      expect(mockSDK.session.prompt).toHaveBeenCalledWith(
+      expect(mockPrompt).toHaveBeenCalledWith(
         expect.objectContaining({
-          parts: [
-            { type: "text", text: "[Use web-design skill]\n\nHello with image" },
-            {
-              type: "file",
-              mime: "image/png",
-              url: "data:image/png;base64,abc",
-              filename: "test.png",
-            },
-          ],
+          text: "/skill:web-design Hello with image",
+          images: [{ type: "image", mimeType: "image/png", data: "abc" }],
         }),
       )
     })
 
-    it("should set session status to running when sending", async () => {
+    it("sets session status to running when sending", async () => {
       const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
 
       await act(async () => {
@@ -237,8 +180,8 @@ describe("use-sessions", () => {
       expect(useSessionStore.getState().sessionStatus["session-1"]).toBe("running")
     })
 
-    it("should handle SDK errors gracefully", async () => {
-      mockSDK.session.prompt.mockRejectedValueOnce(new Error("API Error"))
+    it("handles prompt errors gracefully", async () => {
+      mockPrompt.mockRejectedValueOnce(new Error("API Error"))
 
       const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
 
@@ -254,19 +197,19 @@ describe("use-sessions", () => {
   })
 
   describe("session management", () => {
-    it("should return sessions from query", () => {
+    it("returns sessions from query", () => {
       const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
 
       expect(result.current.sessions).toEqual(mockSessions)
     })
 
-    it("should return current session based on currentSessionId", () => {
+    it("returns current session based on currentSessionId", () => {
       const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
 
       expect(result.current.currentSession).toEqual(mockSessions[0])
     })
 
-    it("should return isServerReady state", () => {
+    it("returns isServerReady state", () => {
       const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
 
       expect(result.current.isServerReady).toBe(true)
@@ -274,18 +217,36 @@ describe("use-sessions", () => {
   })
 
   describe("stopSession", () => {
-    it("should call abort and set status to idle", async () => {
+    it("aborts the Pi session and sets status to idle", async () => {
       const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
 
       await act(async () => {
         await result.current.stopSession()
       })
 
-      expect(mockSDK.session.abort).toHaveBeenCalledWith({
-        sessionID: "session-1",
-        directory: "/mock/cwd/1",
-      })
+      expect(mockAbort).toHaveBeenCalledWith({ sessionID: "session-1" })
       expect(useSessionStore.getState().sessionStatus["session-1"]).toBe("idle")
+    })
+  })
+
+  describe("tree navigation", () => {
+    it("uses Pi tree navigation for timeline revert", async () => {
+      useSessionStore
+        .getState()
+        .setSessionRevert("session-1", { messageID: "stale-message" })
+
+      const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
+
+      await act(async () => {
+        await result.current.revertToMessage("msg-1")
+      })
+
+      expect(mockNavigateTree).toHaveBeenCalledWith({
+        sessionID: "session-1",
+        targetId: "msg-1",
+        summarize: false,
+      })
+      expect(useSessionStore.getState().sessionRevert["session-1"]).toBeNull()
     })
   })
 })

--- a/apps/desktop/src/hooks/use-sessions.ts
+++ b/apps/desktop/src/hooks/use-sessions.ts
@@ -19,17 +19,24 @@ import {
   createSessionDir,
   sessionKeys,
 } from "@/hooks/use-session-data"
-import { useGlobalEvents, useSDK, useConnectionStatus, type Event } from "@/context/global-events"
+import { useGlobalEvents, useConnectionStatus, type Event } from "@/context/global-events"
 import { useModelStore } from "@/hooks/use-models"
 import { useAgentStore } from "@/hooks/use-agents"
 import { withErrorHandler } from "@/lib/async-utils"
 import { bridge } from "@/lib/bridge"
-import type { Part, FilePartInput, TextPartInput } from "@opencode-ai/sdk/v2/client"
+import type {
+  AgentImageContent as BridgeAgentImageContent,
+  AgentMessage as BridgeAgentMessage,
+} from "@dilag/desktop-bridge"
 import type { FileUIPart } from "ai"
 import { formatElementWithAncestry, minifyHtml } from "@/lib/html-utils"
 
-// Convert SDK message format to our internal format
-function convertPart(part: Part, messageID: string, sessionID: string): MessagePart {
+// Convert bridge message parts to our internal format.
+function convertPart(
+  part: BridgeAgentMessage["parts"][number],
+  messageID: string,
+  sessionID: string,
+): MessagePart {
   return {
     id: part.id,
     messageID,
@@ -37,34 +44,15 @@ function convertPart(part: Part, messageID: string, sessionID: string): MessageP
     type: part.type as MessagePart["type"],
     text: "text" in part ? part.text : undefined,
     tool: "tool" in part ? part.tool : undefined,
-    state: "state" in part ? part.state : undefined,
+    state: "state" in part ? (part.state as MessagePart["state"]) : undefined,
     // File part fields
     mime: "mime" in part ? part.mime : undefined,
     url: "url" in part ? part.url : undefined,
     filename: "filename" in part ? part.filename : undefined,
     // Step part fields
-    provider: extractSubtaskProvider(part),
-    model: extractSubtaskModel(part),
+    provider: part.provider,
+    model: part.model,
   }
-}
-
-/** SDK v1.4 moved provider + model into a nested `{ providerID, modelID }` object
- *  on SubtaskPart. These helpers tolerate both the old flat shape and the new
- *  nested one, so we don't care which version the server speaks. */
-function extractSubtaskProvider(part: unknown): string | undefined {
-  const p = part as { provider?: unknown; model?: { providerID?: unknown } }
-  if (typeof p.provider === "string") return p.provider
-  if (p.model && typeof p.model.providerID === "string") return p.model.providerID
-  return undefined
-}
-
-function extractSubtaskModel(part: unknown): string | undefined {
-  const p = part as { model?: unknown }
-  if (typeof p.model === "string") return p.model
-  if (p.model && typeof (p.model as { modelID?: unknown }).modelID === "string") {
-    return (p.model as { modelID: string }).modelID
-  }
-  return undefined
 }
 
 /**
@@ -77,7 +65,6 @@ function extractSubtaskModel(part: unknown): string | undefined {
  * - CRUD operations: React Query mutations
  */
 export function useSessions() {
-  const sdk = useSDK()
   const queryClient = useQueryClient()
   const { connectionStatus } = useConnectionStatus()
 
@@ -139,12 +126,8 @@ export function useSessions() {
     async (sessionId: string, directory?: string) => {
       // Load session info first to get revert state
       try {
-        const sessionInfo = await sdk.session.get({ sessionID: sessionId, directory })
-        if (sessionInfo?.data?.revert) {
-          setSessionRevert(sessionId, sessionInfo.data.revert)
-        } else {
-          setSessionRevert(sessionId, null)
-        }
+        await bridge.agent.getSession({ sessionID: sessionId, directory: directory ?? "" })
+        setSessionRevert(sessionId, null)
       } catch (err) {
         console.debug(`[loadSessionMessages(${sessionId})] Failed to get session info:`, err)
       }
@@ -152,16 +135,16 @@ export function useSessions() {
       // Load messages
       let response
       try {
-        response = await sdk.session.messages({ sessionID: sessionId, directory })
+        response = await bridge.agent.getMessages({ sessionID: sessionId, directory: directory ?? "" })
       } catch (err) {
-        // Session might not exist in OpenCode yet - this is expected
+        // Session might not exist in the agent runtime yet - this is expected
         console.debug(`[loadSessionMessages(${sessionId})] Session may not exist yet:`, err)
         setMessages(sessionId, [])
         return
       }
 
-      if (response?.data) {
-        const msgs = response.data.map((msg) => ({
+      if (response) {
+        const msgs = response.map((msg) => ({
           id: msg.info.id,
           sessionID: msg.info.sessionID,
           role: msg.info.role as "user" | "assistant",
@@ -171,14 +154,14 @@ export function useSessions() {
 
         // Set parts for each message
         const state = useSessionStore.getState()
-        response.data.forEach((msg) => {
+        response.forEach((msg) => {
           msg.parts?.forEach((part) => {
             state.updatePart(msg.info.id, convertPart(part, msg.info.id, msg.info.sessionID))
           })
         })
       }
     },
-    [sdk, setMessages, setSessionRevert],
+    [setMessages, setSessionRevert],
   )
 
   // Handle reconnection bootstrap - refetch state after SSE reconnects
@@ -241,7 +224,7 @@ export function useSessions() {
     loadSessionMessages,
   ])
 
-  // Listen for session.updated events to sync OpenCode data (title, updated_at) to dilag
+  // Listen for session.updated events to sync agent data (title, updated_at) to Dilag.
   useEffect(() => {
     if (!currentSessionId) return
 
@@ -260,13 +243,13 @@ export function useSessions() {
         if (info?.id === currentSessionId && isMountedRef.current) {
           const updates: { name?: string; updated_at?: string } = {}
 
-          // Sync title if OpenCode generated a real title
+          // Sync title if the agent generated a real title.
           if (info?.title && !isDefaultTitle(info.title)) {
-            console.log("[useSessions] Title from OpenCode:", info.title)
+            console.log("[useSessions] Title from agent:", info.title)
             updates.name = info.title
           }
 
-          // Sync updated_at timestamp from OpenCode SDK
+          // Sync updated_at timestamp from the agent runtime.
           if (info?.time?.updated) {
             updates.updated_at = new Date(info.time.updated).toISOString()
           }
@@ -294,11 +277,8 @@ export function useSessions() {
         const cwd = await createSessionDir(dirId)
 
         // No project initialization needed - AI generates HTML screens directly
-        const response = await sdk.session.create({ directory: cwd })
-        if (!response.data) {
-          throw new Error("Failed to create session")
-        }
-        const sessionId = response.data.id
+        const response = await bridge.agent.createSession({ directory: cwd })
+        const sessionId = response.id
 
         // Create session metadata
         const now = new Date().toISOString()
@@ -325,7 +305,7 @@ export function useSessions() {
         return null
       }
     },
-    [sessions.length, setError, setCurrentSessionId, setMessages, sdk, saveSession],
+    [sessions.length, setError, setCurrentSessionId, setMessages, saveSession],
   )
 
   const selectSession = useCallback(
@@ -342,14 +322,11 @@ export function useSessions() {
   const deleteSession = useCallback(
     async (sessionId: string) => {
       try {
-        // Get session's directory
-        const session = sessions.find((s) => s.id === sessionId)
-
-        // Delete from OpenCode (may not exist if never sent a message)
+        // Delete from the agent runtime (may not exist if never sent a message)
         await withErrorHandler(
-          () => sdk.session.delete({ sessionID: sessionId, directory: session?.cwd }),
+          () => bridge.agent.deleteSession({ sessionID: sessionId }),
           `deleteSession(${sessionId})`,
-          undefined, // Continue on error - session may not exist in OpenCode
+          undefined, // Continue on error - session may not exist in the runtime
         )
 
         // Delete local metadata (React Query mutation)
@@ -362,7 +339,7 @@ export function useSessions() {
         console.error("Failed to delete session:", err)
       }
     },
-    [sessions, removeSession, clearSessionData, setError, sdk],
+    [removeSession, clearSessionData, setError],
   )
 
   const stopSession = useCallback(async () => {
@@ -372,10 +349,7 @@ export function useSessions() {
     const { abortRunningTools } = useSessionStore.getState()
 
     try {
-      await sdk.session.abort({
-        sessionID: currentSessionId,
-        directory: currentSession.cwd,
-      })
+      await bridge.agent.abort({ sessionID: currentSessionId })
       setSessionStatus(currentSessionId, "idle")
       // Also abort any stuck running tools (backend may not clean them up)
       abortRunningTools(currentSessionId)
@@ -385,71 +359,34 @@ export function useSessions() {
       setSessionStatus(currentSessionId, "idle")
       abortRunningTools(currentSessionId)
     }
-  }, [currentSessionId, currentSession, sdk, setSessionStatus])
+  }, [currentSessionId, currentSession, setSessionStatus])
 
-  // Fork session from a specific message - creates a new session with history up to that message
-  // Uses parent's directory so OpenCode can find the forked messages
+  // Navigate the Pi session tree to a previous message. Pi keeps this in the same
+  // session file instead of creating a separate revert state.
   const forkSession = useCallback(
     async (messageId: string): Promise<string | null> => {
       if (!currentSessionId || !currentSession) return null
 
       try {
         setError(null)
-
-        // Call SDK to fork the session - uses parent's directory
-        const response = await sdk.session.fork({
+        await bridge.agent.navigateTree({
           sessionID: currentSessionId,
-          messageID: messageId,
-          directory: currentSession.cwd,
+          targetId: messageId,
+          summarize: false,
         })
-
-        if (!response.data) {
-          throw new Error("Failed to fork session")
-        }
-
-        const forkedSession = response.data
-
-        // Use parent's directory - OpenCode associates the forked session with this directory
-        // This means screens will persist, but chat history is properly forked
-        const now = new Date().toISOString()
-        const sessionMeta: SessionMeta = {
-          id: forkedSession.id,
-          name: `Fork of ${currentSession.name}`,
-          created_at: now,
-          updated_at: now,
-          cwd: currentSession.cwd,
-          parentID: currentSessionId,
-          platform: currentSession.platform,
-        }
-
-        // Save to the desktop bridge and update React Query cache.
-        await saveSession(sessionMeta)
-
-        // Switch to the forked session
-        setCurrentSessionId(forkedSession.id)
-        await loadSessionMessages(forkedSession.id, currentSession.cwd)
-
-        return forkedSession.id
+        await loadSessionMessages(currentSessionId, currentSession.cwd)
+        return currentSessionId
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to fork session")
-        console.error("Failed to fork session:", err)
+        setError(err instanceof Error ? err.message : "Failed to navigate session tree")
+        console.error("Failed to navigate session tree:", err)
         return null
       }
     },
-    [
-      currentSessionId,
-      currentSession,
-      sdk,
-      saveSession,
-      setCurrentSessionId,
-      loadSessionMessages,
-      setError,
-    ],
+    [currentSessionId, currentSession, loadSessionMessages, setError],
   )
 
-  // Revert session to a specific message - hides this message and all after it
-  // Messages are NOT deleted - just filtered out based on session.revert state
-  // Actual deletion happens when user sends a new message (server handles cleanup)
+  // Navigate the Pi session tree to a specific message. This replaces the old
+  // revert/unrevert API with Pi's tree cursor model.
   const revertToMessage = useCallback(
     async (messageId: string): Promise<boolean> => {
       if (!currentSessionId || !currentSession) return false
@@ -457,17 +394,13 @@ export function useSessions() {
       try {
         setError(null)
 
-        // Call SDK to revert the session - returns updated session with revert state
-        const response = await sdk.session.revert({
+        await bridge.agent.navigateTree({
           sessionID: currentSessionId,
-          messageID: messageId,
-          directory: currentSession.cwd,
+          targetId: messageId,
+          summarize: false,
         })
-
-        // Set revert state from response (also updated via SSE, but set immediately for responsiveness)
-        if (response?.data?.revert) {
-          setSessionRevert(currentSessionId, response.data.revert)
-        }
+        await loadSessionMessages(currentSessionId, currentSession.cwd)
+        setSessionRevert(currentSessionId, null)
 
         return true
       } catch (err) {
@@ -476,25 +409,16 @@ export function useSessions() {
         return false
       }
     },
-    [currentSessionId, currentSession, sdk, setError, setSessionRevert],
+    [currentSessionId, currentSession, loadSessionMessages, setError, setSessionRevert],
   )
 
-  // Unrevert session - restores visibility of reverted messages
-  // Messages are NOT reloaded - they're already in state, just filtered by revert state
+  // Clear any stale client-side revert state left from older session data.
   const unrevertSession = useCallback(async (): Promise<boolean> => {
     if (!currentSessionId || !currentSession) return false
 
     try {
       setError(null)
 
-      // Call SDK to unrevert the session
-      await sdk.session.unrevert({
-        sessionID: currentSessionId,
-        directory: currentSession.cwd,
-      })
-
-      // Clear local revert state - messages will now be unfiltered
-      // (also updated via SSE, but set immediately for responsiveness)
       setSessionRevert(currentSessionId, null)
 
       return true
@@ -503,7 +427,7 @@ export function useSessions() {
       console.error("Failed to unrevert session:", err)
       return false
     }
-  }, [currentSessionId, currentSession, sdk, setError, setSessionRevert])
+  }, [currentSessionId, currentSession, setError, setSessionRevert])
 
   // Fork session with designs only - creates a new session and copies screen designs (no chat history)
   const forkSessionDesignsOnly = useCallback(async (): Promise<string | null> => {
@@ -516,12 +440,9 @@ export function useSessions() {
       const dirId = crypto.randomUUID()
       const cwd = await createSessionDir(dirId)
 
-      // Create session in OpenCode with the new directory
-      const response = await sdk.session.create({ directory: cwd })
-      if (!response.data) {
-        throw new Error("Failed to create session")
-      }
-      const newSessionId = response.data.id
+      // Create session in the agent runtime with the new directory
+      const response = await bridge.agent.createSession({ directory: cwd })
+      const newSessionId = response.id
 
       // Copy designs from current session to new session
       await bridge.designs.copyBetweenSessions({
@@ -557,7 +478,6 @@ export function useSessions() {
   }, [
     currentSessionId,
     currentSession,
-    sdk,
     saveSession,
     setCurrentSessionId,
     setMessages,
@@ -579,16 +499,15 @@ export function useSessions() {
         return
       }
 
-      // Get selected model and variant from store
+      // Get selected model and reasoning level from store
       const { selectedModel, variants } = useModelStore.getState()
+      const selectedThinkingLevel = selectedModel
+        ? variants[`${selectedModel.providerID}/${selectedModel.modelID}`]
+        : undefined
       // Get selected agent from store
       const { selectedAgent } = useAgentStore.getState()
       const agentName = selectedAgent ?? "build"
       const directory = currentSession.cwd
-
-      // Get variant for current model
-      const modelKey = selectedModel ? `${selectedModel.providerID}/${selectedModel.modelID}` : null
-      const variant = modelKey ? variants[modelKey] : undefined
 
       try {
         setError(null)
@@ -599,31 +518,25 @@ export function useSessions() {
         // Clear any previous session error
         setSessionError(currentSessionId, null)
 
-        // Send message using SDK - fire and forget
-        // User message will be added via server events (message.updated)
-        const model = selectedModel ?? {
-          providerID: "anthropic",
-          modelID: "claude-sonnet-4-20250514",
-        }
         console.log("[sendMessage] agent:", agentName)
-        console.log("[sendMessage] model:", `${model.providerID}/${model.modelID}`)
+        console.log(
+          "[sendMessage] model:",
+          selectedModel ? `${selectedModel.providerID}/${selectedModel.modelID}` : "first available",
+        )
         console.log("[sendMessage] directory:", directory)
 
         // On first message, prepend skill instruction
         const platform = currentSession.platform ?? "web"
         const isFirstMessage = messages.length === 0
-        const skillHint = isFirstMessage ? `[Use ${platform}-design skill]\n\n` : ""
+        const skillHint = isFirstMessage ? `/skill:${platform}-design ` : ""
 
-        // Build parts array with text and optional file attachments
-        const parts: (TextPartInput | FilePartInput)[] = [
-          { type: "text", text: skillHint + content },
-        ]
+        let promptText = skillHint + content
 
-        // Add file parts if any
         // HTML screen references: prepend @ScreenName inline, append HTML context at end
-        // Other files (images, etc.) are sent as file parts
         const screenContexts: string[] = []
         const screenNames: string[] = []
+        const fileNotes: string[] = []
+        const images: BridgeAgentImageContent[] = []
 
         if (files && files.length > 0) {
           for (const file of files) {
@@ -683,14 +596,19 @@ export function useSessions() {
                     console.error("[sendMessage] Failed to decode HTML content:", e)
                   }
                 }
-              } else {
-                // Other files (images, etc.) sent as file parts
-                parts.push({
-                  type: "file",
-                  mime: file.mediaType || "application/octet-stream",
-                  url: file.url,
-                  filename: file.filename,
-                })
+              } else if (file.mediaType?.startsWith("image/")) {
+                const dataUrlMatch = file.url.match(/^data:([^;,]+);base64,(.+)$/)
+                if (dataUrlMatch) {
+                  images.push({
+                    type: "image",
+                    mimeType: dataUrlMatch[1] || file.mediaType,
+                    data: dataUrlMatch[2],
+                  })
+                } else if (file.filename) {
+                  fileNotes.push(`Attached image not inlined: ${file.filename}`)
+                }
+              } else if (file.filename) {
+                fileNotes.push(`Attached file not inlined: ${file.filename}`)
               }
             }
           }
@@ -700,30 +618,30 @@ export function useSessions() {
         if (screenNames.length > 0) {
           const inlineRefs = screenNames.map((name) => `@${name}`).join(" ")
           const contextBlock = screenContexts.join("\n\n")
-          parts[0] = {
-            type: "text",
-            text: `${inlineRefs} ${skillHint}${content}\n\n${contextBlock}`,
-          }
+          promptText = `${skillHint}${inlineRefs} ${content}\n\n${contextBlock}`
         }
 
-        console.log("[sendMessage] calling sdk.session.prompt with:", {
+        if (fileNotes.length > 0) {
+          promptText += `\n\n${fileNotes.join("\n")}`
+        }
+
+        console.log("[sendMessage] calling bridge.agent.prompt with:", {
           sessionID: currentSessionId,
           agent: agentName,
-          model,
-          variant,
-          partsCount: parts.length,
+          model: selectedModel,
+          thinkingLevel: selectedThinkingLevel,
         })
-        sdk.session
+        bridge.agent
           .prompt({
             sessionID: currentSessionId,
             directory,
-            agent: agentName,
-            model,
-            parts,
-            variant,
+            text: promptText,
+            images,
+            model: selectedModel,
+            thinkingLevel: selectedThinkingLevel,
           })
-          .then((response) => {
-            console.log("[sendMessage] prompt response:", response)
+          .then(() => {
+            console.log("[sendMessage] prompt accepted")
           })
           .catch((err) => {
             if (!isMountedRef.current) return
@@ -737,7 +655,7 @@ export function useSessions() {
         console.error("Failed to send message:", err)
       }
     },
-    [currentSessionId, currentSession, messages, setError, setSessionStatus, setSessionError, sdk],
+    [currentSessionId, currentSession, messages, setError, setSessionStatus, setSessionError],
   )
 
   const toggleFavorite = useCallback(

--- a/apps/desktop/src/hooks/use-sessions.ts
+++ b/apps/desktop/src/hooks/use-sessions.ts
@@ -135,7 +135,10 @@ export function useSessions() {
       // Load messages
       let response
       try {
-        response = await bridge.agent.getMessages({ sessionID: sessionId, directory: directory ?? "" })
+        response = await bridge.agent.getMessages({
+          sessionID: sessionId,
+          directory: directory ?? "",
+        })
       } catch (err) {
         // Session might not exist in the agent runtime yet - this is expected
         console.debug(`[loadSessionMessages(${sessionId})] Session may not exist yet:`, err)
@@ -475,14 +478,7 @@ export function useSessions() {
       console.error("Failed to fork session with designs:", err)
       return null
     }
-  }, [
-    currentSessionId,
-    currentSession,
-    saveSession,
-    setCurrentSessionId,
-    setMessages,
-    setError,
-  ])
+  }, [currentSessionId, currentSession, saveSession, setCurrentSessionId, setMessages, setError])
 
   const sendMessage = useCallback(
     async (content: string, files?: FileUIPart[]) => {
@@ -521,7 +517,9 @@ export function useSessions() {
         console.log("[sendMessage] agent:", agentName)
         console.log(
           "[sendMessage] model:",
-          selectedModel ? `${selectedModel.providerID}/${selectedModel.modelID}` : "first available",
+          selectedModel
+            ? `${selectedModel.providerID}/${selectedModel.modelID}`
+            : "first available",
         )
         console.log("[sendMessage] directory:", directory)
 

--- a/apps/desktop/src/routes/studio.$sessionId.tsx
+++ b/apps/desktop/src/routes/studio.$sessionId.tsx
@@ -6,7 +6,6 @@ import { useSessions } from "@/hooks/use-sessions"
 import { useSessionMutations } from "@/hooks/use-session-data"
 import { useSessionDesigns, designKeys } from "@/hooks/use-designs"
 import { usePngGenerator } from "@/hooks/use-png-generator"
-import { useSDK } from "@/context/global-events"
 import { useChatWidth } from "@/hooks/use-chat-width"
 import {
   useScreenPositions,
@@ -88,7 +87,6 @@ function StudioPage() {
   const { selectSession, sendMessage, sessions, isServerReady, isLoading, forkSessionDesignsOnly } =
     useSessions()
   const { updateSession } = useSessionMutations()
-  const sdk = useSDK()
 
   const currentSession = sessions.find((s: { id: string }) => s.id === sessionId)
   const { data: designs = [] } = useSessionDesigns(currentSession?.cwd)
@@ -201,14 +199,10 @@ function StudioPage() {
       updates: { name: newName.trim() },
     })
 
-    await sdk.session.update({
-      sessionID: sessionId,
-      title: newName.trim(),
-      directory: currentSession.cwd,
-    })
+    await bridge.agent.renameSession({ sessionID: sessionId, name: newName.trim() })
 
     setRenameOpen(false)
-  }, [currentSession, newName, sessionId, updateSession, sdk])
+  }, [currentSession, newName, sessionId, updateSession])
 
   // Auto-send initial prompt if stored
   useEffect(() => {


### PR DESCRIPTION
## Summary

Routes desktop chat/session behavior through Pi sessions and normalizes Pi runtime events for the renderer.

## Changes

- Create, fetch, prompt, abort, rename, delete, and navigate Pi sessions through bridge.agent
- Normalize agent events into renderer session state
- Update chat, permission, question, and tool rendering for Pi events
- Add regression coverage for session and chat behavior

## Testing

- bun run fmt:check
- bun run typecheck
- bun run test
- bun run lint
- bun run build
- stack sync --dry-run