### PR TITLE
feat: Add project workspaces

### DIFF
--- a/apps/desktop/electron/ipc/designs.ts
+++ b/apps/desktop/electron/ipc/designs.ts
@@ -61,6 +61,7 @@ async function loadDesignsFromDir(dir: string, seen: Set<string>, out: DesignFil
     seen.add(entry.name)
     out.push({
       filename: entry.name,
+      file_path: filePath,
       title: extractHtmlAttr(html, "data-title") ?? titleFromFilename(entry.name),
       screen_type: extractHtmlAttr(html, "data-screen-type") ?? "web",
       html,
@@ -73,8 +74,9 @@ async function loadDesignsFromDir(dir: string, seen: Set<string>, out: DesignFil
 export async function loadDesignsForSession(sessionCwd: string): Promise<DesignFile[]> {
   const designs: DesignFile[] = []
   const seen = new Set<string>()
-  await loadDesignsFromDir(sessionCwd, seen, designs)
+  await loadDesignsFromDir(path.join(sessionCwd, ".designs"), seen, designs)
   await loadDesignsFromDir(path.join(sessionCwd, "screens"), seen, designs)
+  await loadDesignsFromDir(sessionCwd, seen, designs)
   return designs.sort((a, b) => a.modified_at - b.modified_at)
 }
 

--- a/apps/desktop/electron/ipc/host.ts
+++ b/apps/desktop/electron/ipc/host.ts
@@ -17,6 +17,7 @@ import {
   isAgentRuntimeRunning,
   listAgentProviders,
   listAgentQuestions,
+  listAgentSessions,
   loginAgentOAuthProvider,
   navigateAgentTree,
   promptAgentSession,
@@ -41,6 +42,16 @@ import {
   toggleSessionFavorite,
 } from "./sessions.js"
 import { installSkills, listInstalledSkills, previewSkills, removeSkill } from "./skills.js"
+import {
+  addExistingProject,
+  createProject,
+  dismissLegacySessionsNotice,
+  getLegacySessionsNotice,
+  listProjects,
+  removeProject,
+  touchProject,
+  updateProject,
+} from "./projects.js"
 
 export function initializeHost() {
   return startAgentRuntime()
@@ -82,6 +93,9 @@ export function registerHostHandlers(getWindow: () => BrowserWindow | null) {
   ipcMain.handle(CHANNELS.agent.createSession, (_event, args: { directory: string }) =>
     createAgentSessionForDirectory(args),
   )
+  ipcMain.handle(CHANNELS.agent.listSessions, (_event, args: { directory: string }) =>
+    listAgentSessions(args),
+  )
   ipcMain.handle(
     CHANNELS.agent.getSession,
     (_event, args: { sessionID: string; directory: string }) => getAgentSession(args),
@@ -109,10 +123,12 @@ export function registerHostHandlers(getWindow: () => BrowserWindow | null) {
   )
   ipcMain.handle(
     CHANNELS.agent.renameSession,
-    (_event, args: { sessionID: string; name: string }) => renameAgentSession(args),
+    (_event, args: { sessionID: string; name: string; directory?: string }) =>
+      renameAgentSession(args),
   )
-  ipcMain.handle(CHANNELS.agent.deleteSession, (_event, args: { sessionID: string }) =>
-    deleteAgentSession(args),
+  ipcMain.handle(
+    CHANNELS.agent.deleteSession,
+    (_event, args: { sessionID: string; directory?: string }) => deleteAgentSession(args),
   )
   ipcMain.handle(CHANNELS.agent.listQuestions, listAgentQuestions)
   ipcMain.handle(
@@ -159,13 +175,43 @@ export function registerHostHandlers(getWindow: () => BrowserWindow | null) {
     toggleSessionFavorite(args.sessionId),
   )
 
+  ipcMain.handle(CHANNELS.projects.list, listProjects)
+  ipcMain.handle(CHANNELS.projects.create, (_event, args: Parameters<typeof createProject>[0]) =>
+    createProject(args),
+  )
+  ipcMain.handle(
+    CHANNELS.projects.addExisting,
+    (_event, args: Parameters<typeof addExistingProject>[0]) => addExistingProject(args),
+  )
+  ipcMain.handle(CHANNELS.projects.update, (_event, args: Parameters<typeof updateProject>[0]) =>
+    updateProject(args),
+  )
+  ipcMain.handle(CHANNELS.projects.remove, (_event, args: Parameters<typeof removeProject>[0]) =>
+    removeProject(args),
+  )
+  ipcMain.handle(CHANNELS.projects.touch, (_event, args: Parameters<typeof touchProject>[0]) =>
+    touchProject(args),
+  )
+  ipcMain.handle(CHANNELS.projects.getLegacyNotice, getLegacySessionsNotice)
+  ipcMain.handle(CHANNELS.projects.dismissLegacyNotice, dismissLegacySessionsNotice)
+
   ipcMain.handle(CHANNELS.designs.loadForSession, (_event, args: { sessionCwd: string }) =>
     loadDesignsForSession(args.sessionCwd),
   )
   ipcMain.handle(
     CHANNELS.designs.copyBetweenSessions,
-    (_event, args: { sourceCwd: string; destCwd: string }) =>
-      copyHtmlFiles(path.join(args.sourceCwd, "screens"), path.join(args.destCwd, "screens")),
+    async (_event, args: { sourceCwd: string; destCwd: string }) => {
+      const copied = await copyHtmlFiles(
+        path.join(args.sourceCwd, ".designs"),
+        path.join(args.destCwd, ".designs"),
+      )
+      if (copied === 0) {
+        await copyHtmlFiles(
+          path.join(args.sourceCwd, "screens"),
+          path.join(args.destCwd, ".designs"),
+        )
+      }
+    },
   )
   ipcMain.handle(CHANNELS.designs.delete, (_event, args: { filePath: string }) =>
     fsp.rm(args.filePath),
@@ -217,6 +263,13 @@ export function registerHostHandlers(getWindow: () => BrowserWindow | null) {
       ? await dialog.showSaveDialog(window, options)
       : await dialog.showSaveDialog(options)
     return result.canceled ? null : (result.filePath ?? null)
+  })
+  ipcMain.handle(CHANNELS.dialog.openDirectory, async () => {
+    const window = getWindow()
+    const result = window
+      ? await dialog.showOpenDialog(window, { properties: ["openDirectory", "createDirectory"] })
+      : await dialog.showOpenDialog({ properties: ["openDirectory", "createDirectory"] })
+    return result.canceled ? null : (result.filePaths[0] ?? null)
   })
   ipcMain.handle(CHANNELS.shell.openExternal, (_event, url: string) => shell.openExternal(url))
 

--- a/apps/desktop/electron/ipc/paths.ts
+++ b/apps/desktop/electron/ipc/paths.ts
@@ -24,6 +24,18 @@ export function getSessionsFile(): string {
   return path.join(getDilagDir(), "sessions.json")
 }
 
+export function getStateDbPath(): string {
+  return path.join(getDilagDir(), "state.sqlite")
+}
+
+export function getDilagSkillsDir(): string {
+  return path.join(getDilagDir(), "skills")
+}
+
+export function getDefaultProjectsDir(): string {
+  return path.join(os.homedir(), "dilag")
+}
+
 export function getPiAgentDir(): string {
   return path.join(getDilagDir(), "pi")
 }

--- a/apps/desktop/electron/ipc/pi.ts
+++ b/apps/desktop/electron/ipc/pi.ts
@@ -15,6 +15,7 @@ import type {
   AgentQuestionRequest,
   AgentRuntimeInfo,
   AgentSessionInfo,
+  AgentSessionSummary,
   AgentThinkingLevel,
   AgentTreeNode as BridgeAgentTreeNode,
 } from "@dilag/desktop-bridge"
@@ -23,7 +24,7 @@ import path from "node:path"
 import { randomUUID } from "node:crypto"
 import { Type } from "typebox"
 import { CHANNELS } from "../shared/channels.js"
-import { getPiAgentDir, resolveDesignAssetDir } from "./paths.js"
+import { getDilagSkillsDir, getPiAgentDir, resolveDesignAssetDir } from "./paths.js"
 
 type EventSender = (channel: string, event: unknown) => void
 
@@ -228,6 +229,22 @@ export async function createAgentSessionForDirectory(args: {
   return toAgentSessionInfo(runtime)
 }
 
+export async function listAgentSessions(args: {
+  directory: string
+}): Promise<AgentSessionSummary[]> {
+  const pi = await loadPi()
+  const infos = await pi.SessionManager.list(args.directory, getPiSessionDir(args.directory))
+  return infos.map((info) => ({
+    id: info.id,
+    cwd: info.cwd || args.directory,
+    name: info.name,
+    created_at: info.created.toISOString(),
+    updated_at: info.modified.toISOString(),
+    message_count: info.messageCount,
+    first_message: info.firstMessage,
+  }))
+}
+
 export async function getAgentSession(args: {
   sessionID: string
   directory: string
@@ -274,21 +291,38 @@ export async function abortAgentSession(args: { sessionID: string }): Promise<vo
   emitSessionIdle(runtime.id)
 }
 
-export async function renameAgentSession(args: { sessionID: string; name: string }): Promise<void> {
-  const runtime = getRuntimeSession(args.sessionID)
+export async function renameAgentSession(args: {
+  sessionID: string
+  name: string
+  directory?: string
+}): Promise<void> {
+  const runtime = args.directory
+    ? await ensureRuntimeSession(args.sessionID, args.directory)
+    : getRuntimeSession(args.sessionID)
   runtime.session.setSessionName(args.name)
 }
 
-export async function deleteAgentSession(args: { sessionID: string }): Promise<void> {
+export async function deleteAgentSession(args: {
+  sessionID: string
+  directory?: string
+}): Promise<void> {
   const runtime = sessions.get(args.sessionID)
-  if (!runtime) return
-  runtime.unsubscribe()
-  await runtime.session.abort().catch(() => undefined)
-  const sessionFile = runtime.session.sessionFile
-  if (sessionFile) {
-    await fsp.rm(sessionFile, { force: true })
+  if (runtime) {
+    runtime.unsubscribe()
+    await runtime.session.abort().catch(() => undefined)
+    const sessionFile = runtime.session.sessionFile
+    if (sessionFile) {
+      await fsp.rm(sessionFile, { force: true })
+    }
+    sessions.delete(args.sessionID)
+    clearQuestionsForSession(args.sessionID)
+    return
   }
-  sessions.delete(args.sessionID)
+
+  if (args.directory) {
+    const sessionFile = await findSessionFile(args.directory, args.sessionID)
+    if (sessionFile) await fsp.rm(sessionFile, { force: true })
+  }
   clearQuestionsForSession(args.sessionID)
 }
 
@@ -417,13 +451,21 @@ async function createPiSession(
   requestedModel?: RequestedAgentModel | null,
   thinkingLevel?: AgentThinkingLevel,
 ) {
-  await ensureDilagPiResources(cwd)
+  await syncDilagSkills()
   const pi = await loadPi()
   const registry = await createModelRegistry()
   const model = requestedModel
     ? registry.find(requestedModel.providerID, requestedModel.modelID)
     : registry.getAvailable()[0]
   const questionTool = await createQuestionTool()
+  const settingsManager = pi.SettingsManager.create(cwd, getPiAgentDir())
+  const resourceLoader = new pi.DefaultResourceLoader({
+    cwd,
+    agentDir: getPiAgentDir(),
+    settingsManager,
+    additionalSkillPaths: [getDilagSkillsDir()],
+  })
+  await resourceLoader.reload()
   const result = await pi.createAgentSession({
     cwd,
     agentDir: getPiAgentDir(),
@@ -431,6 +473,8 @@ async function createPiSession(
     thinkingLevel,
     modelRegistry: registry,
     sessionManager,
+    settingsManager,
+    resourceLoader,
     customTools: [questionTool],
     noTools: "builtin",
     tools: ["read", "bash", "edit", "write", "question"],
@@ -441,11 +485,11 @@ async function createPiSession(
   return result
 }
 
-async function ensureDilagPiResources(cwd: string): Promise<void> {
+async function syncDilagSkills(): Promise<void> {
   const assetDir = resolveDesignAssetDir()
-  const skillsDir = path.join(cwd, ".agents", "skills")
-  const mobileSkillDir = path.join(skillsDir, "mobile-design")
-  const webSkillDir = path.join(skillsDir, "web-design")
+  const skillsDir = getDilagSkillsDir()
+  const mobileSkillDir = path.join(skillsDir, "dilag-mobile-design")
+  const webSkillDir = path.join(skillsDir, "dilag-web-design")
 
   const [common, mobile, web] = await Promise.all([
     fsp.readFile(path.join(assetDir, "designer-common.md"), "utf8"),
@@ -454,28 +498,18 @@ async function ensureDilagPiResources(cwd: string): Promise<void> {
   ])
 
   await Promise.all([
-    fsp.mkdir(path.join(mobileSkillDir, "examples"), { recursive: true }),
-    fsp.mkdir(path.join(webSkillDir, "examples"), { recursive: true }),
+    fsp.mkdir(mobileSkillDir, { recursive: true }),
+    fsp.mkdir(webSkillDir, { recursive: true }),
   ])
 
   await Promise.all([
-    fsp.writeFile(path.join(mobileSkillDir, "SKILL.md"), renderDesignSkill(mobile, common)),
-    fsp.writeFile(path.join(webSkillDir, "SKILL.md"), renderDesignSkill(web, common)),
-    copyAssetIfExists(
-      path.join(assetDir, "examples", "mobile", "wellness.html"),
-      path.join(mobileSkillDir, "examples", "wellness.html"),
+    fsp.writeFile(
+      path.join(mobileSkillDir, "SKILL.md"),
+      renderDesignSkill(mobile, common).replace("name: mobile-design", "name: dilag-mobile-design"),
     ),
-    copyAssetIfExists(
-      path.join(assetDir, "examples", "mobile", "finance.html"),
-      path.join(mobileSkillDir, "examples", "finance.html"),
-    ),
-    copyAssetIfExists(
-      path.join(assetDir, "examples", "web", "editorial.html"),
-      path.join(webSkillDir, "examples", "editorial.html"),
-    ),
-    copyAssetIfExists(
-      path.join(assetDir, "examples", "web", "saas-dashboard.html"),
-      path.join(webSkillDir, "examples", "saas-dashboard.html"),
+    fsp.writeFile(
+      path.join(webSkillDir, "SKILL.md"),
+      renderDesignSkill(web, common).replace("name: web-design", "name: dilag-web-design"),
     ),
   ])
 }
@@ -490,14 +524,6 @@ function renderDesignSkill(template: string, common: string): string {
     .replace("{{BRAND_TOKENS}}", brand)
     .replace("{{DOMAIN_HINT}}", domain)
     .replace("{{REFERENCE_URLS}}", refs)
-}
-
-async function copyAssetIfExists(source: string, target: string): Promise<void> {
-  try {
-    await fsp.copyFile(source, target)
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
-  }
 }
 
 function bindRuntimeSession(session: AgentSession, cwd: string): RuntimeSession {

--- a/apps/desktop/electron/ipc/projects.ts
+++ b/apps/desktop/electron/ipc/projects.ts
@@ -1,0 +1,246 @@
+import fs from "node:fs"
+import fsp from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { randomUUID } from "node:crypto"
+import { DatabaseSync } from "node:sqlite"
+import type { Platform, ProjectMeta } from "@dilag/desktop-bridge"
+import { getDefaultProjectsDir, getSessionsFile, getStateDbPath } from "./paths.js"
+
+const MIGRATIONS = [
+  `CREATE TABLE IF NOT EXISTS projects (
+    id TEXT PRIMARY KEY,
+    path TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    platform TEXT NOT NULL DEFAULT 'web',
+    pinned INTEGER NOT NULL DEFAULT 0,
+    expanded INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL,
+    last_opened_at TEXT NOT NULL
+  )`,
+  `CREATE TABLE IF NOT EXISTS app_state (
+    key TEXT PRIMARY KEY,
+    value_json TEXT NOT NULL
+  )`,
+]
+
+type ProjectRow = {
+  id: string
+  path: string
+  name: string
+  platform: Platform
+  pinned: number
+  expanded: number
+  created_at: string
+  last_opened_at: string
+}
+
+let db: DatabaseSync | undefined
+
+function getDb(): DatabaseSync {
+  if (!db) {
+    fs.mkdirSync(path.dirname(getStateDbPath()), { recursive: true })
+    db = new DatabaseSync(getStateDbPath())
+    db.exec("PRAGMA journal_mode = WAL")
+    db.exec("PRAGMA foreign_keys = ON")
+    for (const migration of MIGRATIONS) db.exec(migration)
+  }
+  return db
+}
+
+function toProject(row: ProjectRow): ProjectMeta {
+  return {
+    id: row.id,
+    path: row.path,
+    name: row.name,
+    platform: row.platform === "mobile" ? "mobile" : "web",
+    pinned: row.pinned === 1,
+    expanded: row.expanded === 1,
+    created_at: row.created_at,
+    last_opened_at: row.last_opened_at,
+  }
+}
+
+function normalizeProjectPath(projectPath: string): string {
+  const expanded = projectPath.startsWith("~")
+    ? path.join(os.homedir(), projectPath.slice(1))
+    : projectPath
+  return path.resolve(expanded)
+}
+
+function slugify(input: string): string {
+  const slug = input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  return slug || "untitled-project"
+}
+
+async function uniqueProjectPath(name: string): Promise<string> {
+  const root = getDefaultProjectsDir()
+  const base = slugify(name)
+  let candidate = path.join(root, base)
+  let suffix = 2
+  while (fs.existsSync(candidate)) {
+    candidate = path.join(root, `${base}-${suffix}`)
+    suffix += 1
+  }
+  return candidate
+}
+
+export function listProjects(): ProjectMeta[] {
+  const rows = getDb()
+    .prepare(
+      `SELECT id, path, name, platform, pinned, expanded, created_at, last_opened_at
+       FROM projects
+       ORDER BY pinned DESC, last_opened_at DESC, created_at DESC`,
+    )
+    .all() as ProjectRow[]
+  return rows.map(toProject)
+}
+
+export async function createProject(args: {
+  name: string
+  platform?: Platform
+}): Promise<ProjectMeta> {
+  const projectPath = await uniqueProjectPath(args.name)
+  await fsp.mkdir(projectPath, { recursive: true })
+  return addProjectAtPath({ path: projectPath, name: args.name, platform: args.platform })
+}
+
+export async function addExistingProject(args: {
+  path: string
+  platform?: Platform
+}): Promise<ProjectMeta> {
+  const projectPath = normalizeProjectPath(args.path)
+  const stat = await fsp.stat(projectPath)
+  if (!stat.isDirectory()) throw new Error("Project path must be a folder")
+  return addProjectAtPath({
+    path: projectPath,
+    name: path.basename(projectPath),
+    platform: args.platform,
+  })
+}
+
+async function addProjectAtPath(args: {
+  path: string
+  name: string
+  platform?: Platform
+}): Promise<ProjectMeta> {
+  const normalizedPath = normalizeProjectPath(args.path)
+  const existing = getProjectByPath(normalizedPath)
+  if (existing) return touchProject({ id: existing.id })
+
+  const now = new Date().toISOString()
+  const project: ProjectMeta = {
+    id: `proj_${randomUUID()}`,
+    path: normalizedPath,
+    name: args.name.trim() || path.basename(normalizedPath),
+    platform: args.platform ?? "web",
+    pinned: false,
+    expanded: true,
+    created_at: now,
+    last_opened_at: now,
+  }
+  getDb()
+    .prepare(
+      `INSERT INTO projects (id, path, name, platform, pinned, expanded, created_at, last_opened_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      project.id,
+      project.path,
+      project.name,
+      project.platform,
+      project.pinned ? 1 : 0,
+      project.expanded ? 1 : 0,
+      project.created_at,
+      project.last_opened_at,
+    )
+  return project
+}
+
+function getProjectByPath(projectPath: string): ProjectMeta | null {
+  const row = getDb()
+    .prepare(
+      `SELECT id, path, name, platform, pinned, expanded, created_at, last_opened_at
+       FROM projects
+       WHERE path = ?`,
+    )
+    .get(normalizeProjectPath(projectPath)) as ProjectRow | undefined
+  return row ? toProject(row) : null
+}
+
+export function getProjectById(id: string): ProjectMeta | null {
+  const row = getDb()
+    .prepare(
+      `SELECT id, path, name, platform, pinned, expanded, created_at, last_opened_at
+       FROM projects
+       WHERE id = ?`,
+    )
+    .get(id) as ProjectRow | undefined
+  return row ? toProject(row) : null
+}
+
+export function updateProject(args: {
+  id: string
+  updates: Partial<Pick<ProjectMeta, "name" | "platform" | "pinned" | "expanded">>
+}): ProjectMeta {
+  const current = getProjectById(args.id)
+  if (!current) throw new Error(`Project ${args.id} not found`)
+  const next: ProjectMeta = { ...current, ...args.updates }
+  getDb()
+    .prepare(
+      `UPDATE projects
+       SET name = ?, platform = ?, pinned = ?, expanded = ?
+       WHERE id = ?`,
+    )
+    .run(next.name, next.platform, next.pinned ? 1 : 0, next.expanded ? 1 : 0, next.id)
+  return next
+}
+
+export function touchProject(args: { id: string }): ProjectMeta {
+  const current = getProjectById(args.id)
+  if (!current) throw new Error(`Project ${args.id} not found`)
+  const lastOpenedAt = new Date().toISOString()
+  getDb().prepare(`UPDATE projects SET last_opened_at = ? WHERE id = ?`).run(lastOpenedAt, args.id)
+  return { ...current, last_opened_at: lastOpenedAt }
+}
+
+export function removeProject(args: { id: string }): void {
+  getDb().prepare(`DELETE FROM projects WHERE id = ?`).run(args.id)
+}
+
+function getAppState<T>(key: string, fallback: T): T {
+  const row = getDb().prepare(`SELECT value_json FROM app_state WHERE key = ?`).get(key) as
+    | { value_json: string }
+    | undefined
+  if (!row) return fallback
+  try {
+    return JSON.parse(row.value_json) as T
+  } catch {
+    return fallback
+  }
+}
+
+function setAppState(key: string, value: unknown): void {
+  getDb()
+    .prepare(
+      `INSERT INTO app_state (key, value_json)
+       VALUES (?, ?)
+       ON CONFLICT(key) DO UPDATE SET value_json = excluded.value_json`,
+    )
+    .run(key, JSON.stringify(value))
+}
+
+export function getLegacySessionsNotice(): { hasLegacySessions: boolean; dismissed: boolean } {
+  return {
+    hasLegacySessions: fs.existsSync(getSessionsFile()),
+    dismissed: getAppState("legacySessionsNoticeDismissed", false),
+  }
+}
+
+export function dismissLegacySessionsNotice(): void {
+  setAppState("legacySessionsNoticeDismissed", true)
+}

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -46,6 +46,7 @@ const bridge: DesktopBridge = {
     setApiKey: (args) => ipcRenderer.invoke(CHANNELS.agent.setApiKey, args),
     loginOAuthProvider: (args) => ipcRenderer.invoke(CHANNELS.agent.loginOAuthProvider, args),
     createSession: (args) => ipcRenderer.invoke(CHANNELS.agent.createSession, args),
+    listSessions: (args) => ipcRenderer.invoke(CHANNELS.agent.listSessions, args),
     getSession: (args) => ipcRenderer.invoke(CHANNELS.agent.getSession, args),
     getMessages: (args) => ipcRenderer.invoke(CHANNELS.agent.getMessages, args),
     prompt: (args) => ipcRenderer.invoke(CHANNELS.agent.prompt, args),
@@ -72,6 +73,16 @@ const bridge: DesktopBridge = {
     loadMeta: () => ipcRenderer.invoke(CHANNELS.sessions.loadMeta),
     deleteMeta: (args) => ipcRenderer.invoke(CHANNELS.sessions.deleteMeta, args),
     toggleFavorite: (args) => ipcRenderer.invoke(CHANNELS.sessions.toggleFavorite, args),
+  },
+  projects: {
+    list: () => ipcRenderer.invoke(CHANNELS.projects.list),
+    create: (args) => ipcRenderer.invoke(CHANNELS.projects.create, args),
+    addExisting: (args) => ipcRenderer.invoke(CHANNELS.projects.addExisting, args),
+    update: (args) => ipcRenderer.invoke(CHANNELS.projects.update, args),
+    remove: (args) => ipcRenderer.invoke(CHANNELS.projects.remove, args),
+    touch: (args) => ipcRenderer.invoke(CHANNELS.projects.touch, args),
+    getLegacyNotice: () => ipcRenderer.invoke(CHANNELS.projects.getLegacyNotice),
+    dismissLegacyNotice: () => ipcRenderer.invoke(CHANNELS.projects.dismissLegacyNotice),
   },
   designs: {
     loadForSession: (args) => ipcRenderer.invoke(CHANNELS.designs.loadForSession, args),
@@ -108,6 +119,7 @@ const bridge: DesktopBridge = {
   },
   dialog: {
     save: (options) => ipcRenderer.invoke(CHANNELS.dialog.save, options),
+    openDirectory: () => ipcRenderer.invoke(CHANNELS.dialog.openDirectory),
   },
   shell: {
     openExternal: (url) => ipcRenderer.invoke(CHANNELS.shell.openExternal, url),

--- a/apps/desktop/electron/shared/channels.ts
+++ b/apps/desktop/electron/shared/channels.ts
@@ -18,6 +18,7 @@ export const CHANNELS = {
     setApiKey: "agent:set-api-key",
     loginOAuthProvider: "agent:login-oauth-provider",
     createSession: "agent:create-session",
+    listSessions: "agent:list-sessions",
     getSession: "agent:get-session",
     getMessages: "agent:get-messages",
     prompt: "agent:prompt",
@@ -44,6 +45,16 @@ export const CHANNELS = {
     loadMeta: "sessions:load-meta",
     deleteMeta: "sessions:delete-meta",
     toggleFavorite: "sessions:toggle-favorite",
+  },
+  projects: {
+    list: "projects:list",
+    create: "projects:create",
+    addExisting: "projects:add-existing",
+    update: "projects:update",
+    remove: "projects:remove",
+    touch: "projects:touch",
+    getLegacyNotice: "projects:get-legacy-notice",
+    dismissLegacyNotice: "projects:dismiss-legacy-notice",
   },
   designs: {
     loadForSession: "designs:load-for-session",
@@ -80,6 +91,7 @@ export const CHANNELS = {
   },
   dialog: {
     save: "dialog:save",
+    openDirectory: "dialog:open-directory",
   },
   shell: {
     openExternal: "shell:open-external",

--- a/apps/desktop/resources/design-assets/designer-common.md
+++ b/apps/desktop/resources/design-assets/designer-common.md
@@ -2,7 +2,7 @@
 
 Use the `write` tool — never inline HTML in your reply.
 
-- Path: `screens/<kebab-name>.html`
+- Path: `.designs/<kebab-name>.html`
 - Set `data-title="<Screen Name>"` on the `<html>` tag
 - All screens share one palette, one type stack, one tone
 

--- a/apps/desktop/resources/design-assets/mobile-designer-prompt.md
+++ b/apps/desktop/resources/design-assets/mobile-designer-prompt.md
@@ -7,15 +7,6 @@ description: Create distinctive, production-grade iOS mobile UI screens. Use for
 
 Generate production-grade iOS screens (iPhone 14 Pro, 393×852). Make them **memorable**, not just correct.
 
-## Reference exemplars
-
-When a requested screen overlaps with a reference, **read the exemplar first** with the `read` tool before writing. Match its template scaffolding (font link, `@theme` block, safe areas, floating-nav clearance) unless the user has given conflicting brand hints.
-
-- `examples/wellness.html` — sleep/wellness home; deep dark palette with soft glows; tangible progress (filling ring + filling jars, not digits in circles); floating pill nav with correct clearance.
-- `examples/finance.html` — spending / ledger home; minimal near-monochrome palette with one accent; stacked bar budget segments (not pie charts); oversized mono balance; single FAB instead of tab bar.
-
-Add your own variation on top — do not copy verbatim.
-
 ## Screens
 
 Produce **3 screens** unless the user says otherwise, picked from:

--- a/apps/desktop/resources/design-assets/web-designer-prompt.md
+++ b/apps/desktop/resources/design-assets/web-designer-prompt.md
@@ -7,15 +7,6 @@ description: Create distinctive, production-grade responsive web UI screens. Use
 
 Generate production-grade responsive web screens. **Clean, focused, memorable.**
 
-## Reference exemplars
-
-When a requested screen overlaps with a reference, **read the exemplar first** with the `read` tool before writing. Match its template scaffolding (font link, `@theme` block, container structure) unless the user has given conflicting brand hints.
-
-- `examples/editorial.html` — typography-led long-form reading; serif + sans pairing; generous measure; minimal chrome.
-- `examples/saas-dashboard.html` — analytics dashboard; cool neutral palette; sidebar + content split; metric cards with sparklines; data list with status chips.
-
-Add your own variation on top — do not copy verbatim.
-
 ## Screens
 
 Produce **3 screens** unless the user says otherwise, picked from:

--- a/apps/desktop/src/components/blocks/layout/app-sidebar.tsx
+++ b/apps/desktop/src/components/blocks/layout/app-sidebar.tsx
@@ -1,15 +1,16 @@
 import { Link, useLocation, useNavigate } from "@tanstack/react-router"
-import { useMemo, useState } from "react"
+import { useMemo } from "react"
 import {
   MagicStick,
   Settings,
   PlugCircle,
   Star,
   AddSquare,
+  AddCircle,
   MenuDots,
   TrashBinMinimalistic,
-  SortVertical,
-  CheckCircle,
+  SidebarMinimalistic,
+  AltArrowDown,
 } from "@solar-icons/react"
 import {
   Sidebar,
@@ -29,17 +30,19 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
 } from "@dilag/ui/dropdown-menu"
 import { AuthSettings } from "@/components/blocks/auth/auth-settings"
+import { useProjectMutations, useProjectsList, getDefaultProject } from "@/hooks/use-projects"
 import { useSessions } from "@/hooks/use-sessions"
+import { bridge } from "@/lib/bridge"
+import type { ProjectMeta } from "@dilag/desktop-bridge"
+import type { SessionMeta } from "@/context/session-store"
 
 function formatRelativeTime(dateStr: string): string {
   const date = new Date(dateStr)
   if (isNaN(date.getTime())) return ""
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
+  const diffMs = Date.now() - date.getTime()
   if (diffMs < 0) return "now"
   const diffMins = Math.floor(diffMs / 60000)
   const diffHours = Math.floor(diffMs / 3600000)
@@ -56,49 +59,64 @@ function formatRelativeTime(dateStr: string): string {
 export function AppSidebar() {
   const location = useLocation()
   const navigate = useNavigate()
-  const { sessions, deleteSession, toggleFavorite } = useSessions()
+  const { sessions, deleteSession } = useSessions()
+  const { data: projects = [] } = useProjectsList()
+  const { createProject, addExistingProject, updateProject, removeProject, touchProject } =
+    useProjectMutations()
 
-  // Filter state
-  const [sortBy, setSortBy] = useState<"created" | "updated">("updated")
-  const [showFilter, setShowFilter] = useState<"all" | "starred">("all")
+  const pinnedProjects = useMemo(() => projects.filter((project) => project.pinned), [projects])
+  const regularProjects = useMemo(() => projects.filter((project) => !project.pinned), [projects])
 
-  // Derive favorites and recent sessions based on filter state
-  const { favorites, recent } = useMemo(() => {
-    // Sort by selected field (updated_at falls back to created_at for older sessions)
-    const getTimestamp = (s: (typeof sessions)[0]) => {
-      if (sortBy === "updated") {
-        return new Date(s.updated_at ?? s.created_at).getTime()
-      }
-      return new Date(s.created_at).getTime()
+  const sessionsByProject = useMemo(() => {
+    const map = new Map<string, SessionMeta[]>()
+    for (const session of sessions) {
+      if (!session.projectId) continue
+      const list = map.get(session.projectId) ?? []
+      list.push(session)
+      map.set(session.projectId, list)
     }
-
-    const sorted = [...sessions].sort((a, b) => getTimestamp(b) - getTimestamp(a))
-
-    // When showing starred only, put all favorites in "recent" section (no separate favorites section)
-    if (showFilter === "starred") {
-      return { favorites: [], recent: sorted.filter((s) => s.favorite).slice(0, 100) }
+    for (const list of map.values()) {
+      list.sort(
+        (a, b) =>
+          new Date(b.updated_at ?? b.created_at).getTime() -
+          new Date(a.updated_at ?? a.created_at).getTime(),
+      )
     }
+    return map
+  }, [sessions])
 
-    // Default: favorites section + non-favorites in recent
-    const favs = sorted.filter((s) => s.favorite)
-    const nonFavs = sorted.filter((s) => !s.favorite).slice(0, 100)
-    return { favorites: favs, recent: nonFavs }
-  }, [sessions, sortBy, showFilter])
-
-  const handleOpenProject = (sessionId: string) => {
-    navigate({ to: "/studio/$sessionId", params: { sessionId } })
+  const openProject = async (project: ProjectMeta) => {
+    await touchProject(project.id)
+    navigate({ to: "/project/$projectId", params: { projectId: project.id } })
   }
 
   const handleNewDesign = () => {
-    navigate({ to: "/" })
+    const project = getDefaultProject(projects)
+    if (project) {
+      navigate({ to: "/project/$projectId", params: { projectId: project.id } })
+    } else {
+      navigate({ to: "/" })
+    }
   }
 
-  const handleToggleFavorite = (sessionId: string) => {
-    toggleFavorite(sessionId)
+  const handleStartFromScratch = async () => {
+    const name = window.prompt("Project name")?.trim()
+    if (!name) return
+    const project = await createProject({ name })
+    navigate({ to: "/project/$projectId", params: { projectId: project.id } })
   }
 
-  const handleDelete = (sessionId: string) => {
-    deleteSession(sessionId)
+  const handleUseExistingFolder = async () => {
+    const folder = await bridge.dialog.openDirectory()
+    if (!folder) return
+    const project = await addExistingProject({ path: folder })
+    navigate({ to: "/project/$projectId", params: { projectId: project.id } })
+  }
+
+  const handleCollapseAll = () => {
+    projects.forEach((project) => {
+      if (project.expanded) updateProject({ id: project.id, updates: { expanded: false } })
+    })
   }
 
   return (
@@ -109,7 +127,6 @@ export function AppSidebar() {
       />
 
       <SidebarContent>
-        {/* Main Navigation */}
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
@@ -135,146 +152,105 @@ export function AppSidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
 
-        {/* Favorites Section - hidden when collapsed */}
-        {favorites.length > 0 && (
+        {pinnedProjects.length > 0 && (
           <SidebarGroup className="group-data-[collapsible=icon]:hidden">
             <SidebarGroupLabel className="text-xs text-muted-foreground px-2">
-              Favorites
+              Pinned
             </SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
-                {favorites.map((session) => (
-                  <SidebarMenuItem key={session.id} className="group/item">
-                    <SidebarMenuButton onClick={() => handleOpenProject(session.id)}>
-                      <span className="truncate text-sm">{session.name}</span>
-                    </SidebarMenuButton>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <SidebarMenuAction
-                          className="opacity-0 group-hover/item:opacity-100 transition-opacity"
-                          showOnHover
-                        >
-                          <MenuDots size={16} />
-                        </SidebarMenuAction>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent side="right" align="start" className="w-40">
-                        <DropdownMenuItem onClick={() => handleToggleFavorite(session.id)}>
-                          <Star size={16} className="mr-2" />
-                          Unfavorite
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          onClick={() => handleDelete(session.id)}
-                          className="text-destructive focus:text-destructive"
-                        >
-                          <TrashBinMinimalistic size={16} className="mr-2" />
-                          Delete
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </SidebarMenuItem>
+                {pinnedProjects.map((project) => (
+                  <ProjectItem
+                    key={project.id}
+                    project={project}
+                    sessions={sessionsByProject.get(project.id) ?? []}
+                    onOpenProject={openProject}
+                    onToggleExpanded={() =>
+                      updateProject({ id: project.id, updates: { expanded: !project.expanded } })
+                    }
+                    onTogglePinned={() =>
+                      updateProject({ id: project.id, updates: { pinned: !project.pinned } })
+                    }
+                    onRemove={() => removeProject(project.id)}
+                    onDeleteSession={deleteSession}
+                  />
                 ))}
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
         )}
 
-        {/* Projects Section - hidden when collapsed */}
-        {recent.length > 0 && (
-          <SidebarGroup className="group-data-[collapsible=icon]:hidden min-h-0 flex-1">
-            <SidebarGroupLabel className="text-xs text-muted-foreground px-2 flex items-center justify-between">
-              <span>Projects</span>
+        <SidebarGroup className="group-data-[collapsible=icon]:hidden min-h-0 flex-1">
+          <SidebarGroupLabel className="text-xs text-muted-foreground px-2 flex items-center justify-between group/projects">
+            <span>Projects</span>
+            <div
+              className={`flex items-center gap-0.5 transition-opacity ${
+                projects.length === 0 ? "opacity-100" : "opacity-0 group-hover/projects:opacity-100"
+              }`}
+            >
+              <button
+                className="p-0.5 rounded hover:bg-sidebar-accent"
+                onClick={handleCollapseAll}
+                title="Collapse all"
+              >
+                <SidebarMinimalistic size={14} />
+              </button>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <button className="p-0.5 rounded hover:bg-sidebar-accent transition-colors">
-                    <SortVertical size={14} className="text-muted-foreground" />
+                  <button className="p-0.5 rounded hover:bg-sidebar-accent" title="Project menu">
+                    <MenuDots size={14} />
                   </button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent side="left" align="start" className="w-44">
-                  <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
-                    Sort by
-                  </DropdownMenuLabel>
-                  <DropdownMenuItem
-                    onClick={() => setSortBy("created")}
-                    className="flex items-center justify-between"
-                  >
-                    <span>Created</span>
-                    {sortBy === "created" && <CheckCircle size={14} className="text-primary" />}
+                <DropdownMenuContent side="right" align="start" className="w-48">
+                  <DropdownMenuItem onClick={handleStartFromScratch}>
+                    Start from scratch
                   </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => setSortBy("updated")}
-                    className="flex items-center justify-between"
-                  >
-                    <span>Updated</span>
-                    {sortBy === "updated" && <CheckCircle size={14} className="text-primary" />}
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
-                    Show
-                  </DropdownMenuLabel>
-                  <DropdownMenuItem
-                    onClick={() => setShowFilter("all")}
-                    className="flex items-center justify-between"
-                  >
-                    <span>All</span>
-                    {showFilter === "all" && <CheckCircle size={14} className="text-primary" />}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => setShowFilter("starred")}
-                    className="flex items-center justify-between"
-                  >
-                    <span>Starred</span>
-                    {showFilter === "starred" && <CheckCircle size={14} className="text-primary" />}
+                  <DropdownMenuItem onClick={handleUseExistingFolder}>
+                    Use an existing folder
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
-            </SidebarGroupLabel>
-            <SidebarGroupContent className="overflow-y-auto">
-              <SidebarMenu>
-                {recent.map((session) => (
-                  <SidebarMenuItem key={session.id} className="group/item">
-                    <SidebarMenuButton onClick={() => handleOpenProject(session.id)}>
-                      <span className="truncate text-sm">{session.name}</span>
-                    </SidebarMenuButton>
-                    <span className="absolute right-2 top-1.5 text-xs text-muted-foreground group-hover/item:opacity-0 transition-opacity pointer-events-none">
-                      {formatRelativeTime(
-                        sortBy === "updated"
-                          ? (session.updated_at ?? session.created_at)
-                          : session.created_at,
-                      )}
-                    </span>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <SidebarMenuAction
-                          className="opacity-0 group-hover/item:opacity-100 transition-opacity"
-                          showOnHover
-                        >
-                          <MenuDots size={16} />
-                        </SidebarMenuAction>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent side="right" align="start" className="w-40">
-                        <DropdownMenuItem onClick={() => handleToggleFavorite(session.id)}>
-                          <Star size={16} className="mr-2" />
-                          Favorite
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          onClick={() => handleDelete(session.id)}
-                          className="text-destructive focus:text-destructive"
-                        >
-                          <TrashBinMinimalistic size={16} className="mr-2" />
-                          Delete
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </SidebarMenuItem>
-                ))}
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
-        )}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button className="p-0.5 rounded hover:bg-sidebar-accent" title="Add project">
+                    <AddCircle size={14} />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent side="right" align="start" className="w-48">
+                  <DropdownMenuItem onClick={handleStartFromScratch}>
+                    Start from scratch
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={handleUseExistingFolder}>
+                    Use an existing folder
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </SidebarGroupLabel>
+          <SidebarGroupContent className="overflow-y-auto">
+            <SidebarMenu>
+              {regularProjects.map((project) => (
+                <ProjectItem
+                  key={project.id}
+                  project={project}
+                  sessions={sessionsByProject.get(project.id) ?? []}
+                  onOpenProject={openProject}
+                  onToggleExpanded={() =>
+                    updateProject({ id: project.id, updates: { expanded: !project.expanded } })
+                  }
+                  onTogglePinned={() =>
+                    updateProject({ id: project.id, updates: { pinned: !project.pinned } })
+                  }
+                  onRemove={() => removeProject(project.id)}
+                  onDeleteSession={deleteSession}
+                />
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
       </SidebarContent>
 
       <SidebarFooter className="relative">
-        {/* Blur gradient overlay for smooth scroll transition */}
         <div className="absolute -top-6 left-0 right-0 h-6 bg-gradient-to-t from-sidebar to-transparent pointer-events-none" />
         <SidebarMenu>
           <SidebarMenuItem>
@@ -302,5 +278,123 @@ export function AppSidebar() {
         </SidebarMenu>
       </SidebarFooter>
     </Sidebar>
+  )
+}
+
+function ProjectItem({
+  project,
+  sessions,
+  onOpenProject,
+  onToggleExpanded,
+  onTogglePinned,
+  onRemove,
+  onDeleteSession,
+}: {
+  project: ProjectMeta
+  sessions: SessionMeta[]
+  onOpenProject: (project: ProjectMeta) => void
+  onToggleExpanded: () => void
+  onTogglePinned: () => void
+  onRemove: () => void
+  onDeleteSession: (sessionId: string) => void
+}) {
+  const navigate = useNavigate()
+
+  return (
+    <>
+      <SidebarMenuItem className="group/item">
+        <SidebarMenuButton onClick={() => onOpenProject(project)}>
+          <button
+            className="-ml-1 p-0.5 rounded hover:bg-sidebar-accent"
+            onClick={(event) => {
+              event.stopPropagation()
+              onToggleExpanded()
+            }}
+          >
+            <AltArrowDown
+              size={13}
+              className={
+                project.expanded ? "transition-transform" : "-rotate-90 transition-transform"
+              }
+            />
+          </button>
+          <span className="truncate text-sm">{project.name}</span>
+        </SidebarMenuButton>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <SidebarMenuAction
+              className="opacity-0 group-hover/item:opacity-100 transition-opacity"
+              showOnHover
+            >
+              <MenuDots size={16} />
+            </SidebarMenuAction>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent side="right" align="start" className="w-44">
+            <DropdownMenuItem onClick={onTogglePinned}>
+              <Star size={16} className="mr-2" />
+              {project.pinned ? "Unpin" : "Pin"}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => bridge.shell.openExternal(`file://${encodeURI(project.path)}`)}
+            >
+              Reveal in Finder
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={onRemove}
+              className="text-destructive focus:text-destructive"
+            >
+              <TrashBinMinimalistic size={16} className="mr-2" />
+              Remove from Projects
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+
+      {project.expanded &&
+        (sessions.length === 0 ? (
+          <SidebarMenuItem>
+            <div className="pl-8 pr-2 py-1 text-xs text-muted-foreground/60">No chats</div>
+          </SidebarMenuItem>
+        ) : (
+          sessions.map((session) => (
+            <SidebarMenuItem key={session.id} className="group/chat">
+              <SidebarMenuButton
+                className="pl-8"
+                onClick={() =>
+                  navigate({
+                    to: "/project/$projectId/session/$sessionId",
+                    params: { projectId: project.id, sessionId: session.id },
+                  })
+                }
+              >
+                <span className="truncate text-sm">{session.name}</span>
+              </SidebarMenuButton>
+              <span className="absolute right-2 top-1.5 text-xs text-muted-foreground group-hover/chat:opacity-0 transition-opacity pointer-events-none">
+                {formatRelativeTime(session.updated_at ?? session.created_at)}
+              </span>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <SidebarMenuAction
+                    className="opacity-0 group-hover/chat:opacity-100 transition-opacity"
+                    showOnHover
+                  >
+                    <MenuDots size={16} />
+                  </SidebarMenuAction>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent side="right" align="start" className="w-40">
+                  <DropdownMenuItem
+                    onClick={() => onDeleteSession(session.id)}
+                    className="text-destructive focus:text-destructive"
+                  >
+                    <TrashBinMinimalistic size={16} className="mr-2" />
+                    Delete chat
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </SidebarMenuItem>
+          ))
+        ))}
+    </>
   )
 }

--- a/apps/desktop/src/components/blocks/layout/auto-collapse-sidebar.tsx
+++ b/apps/desktop/src/components/blocks/layout/auto-collapse-sidebar.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useRef } from "react"
+import { useLocation } from "@tanstack/react-router"
+import { useSidebar } from "@dilag/ui/sidebar"
+import { useProjectsList } from "@/hooks/use-projects"
+
+export function AutoCollapseSidebar() {
+  const location = useLocation()
+  const { open, setOpen, isMobile } = useSidebar()
+  const { data: projects = [], isLoading } = useProjectsList()
+  const didAutoCollapseRef = useRef(false)
+
+  useEffect(() => {
+    if (didAutoCollapseRef.current || isMobile || isLoading) return
+    if (location.pathname !== "/" || projects.length > 0 || !open) return
+
+    setOpen(false)
+    didAutoCollapseRef.current = true
+  }, [isMobile, isLoading, location.pathname, open, projects.length, setOpen])
+
+  return null
+}

--- a/apps/desktop/src/context/session-store.tsx
+++ b/apps/desktop/src/context/session-store.tsx
@@ -56,6 +56,7 @@ export interface SessionMeta {
   parentID?: string // Reference to parent session if forked
   platform?: Platform // "web" (default) or "mobile"
   favorite?: boolean
+  projectId?: string
 }
 
 // Revert state for a session

--- a/apps/desktop/src/hooks/use-designs.test.ts
+++ b/apps/desktop/src/hooks/use-designs.test.ts
@@ -16,6 +16,7 @@ import { useSessionStore } from "@/context/session-store"
 export function makeDesignFile(overrides: Partial<DesignFile> = {}): DesignFile {
   return {
     filename: "home.html",
+    file_path: "/sessions/abc/.designs/home.html",
     title: "Home",
     screen_type: "web",
     html: "<!DOCTYPE html><html><body></body></html>",
@@ -147,7 +148,13 @@ describe("isSessionDesignFileChange", () => {
     expect(isSessionDesignFileChange("screens/home.html", "/sessions/abc")).toBe(true)
   })
 
-  it("matches root html files because the backend loader supports session-root designs", () => {
+  it("matches .designs html files", () => {
+    expect(isSessionDesignFileChange("/sessions/abc/.designs/home.html", "/sessions/abc")).toBe(
+      true,
+    )
+  })
+
+  it("matches root html files because the backend loader supports legacy session-root designs", () => {
     expect(isSessionDesignFileChange("/sessions/abc/home.html", "/sessions/abc")).toBe(true)
   })
 

--- a/apps/desktop/src/hooks/use-designs.ts
+++ b/apps/desktop/src/hooks/use-designs.ts
@@ -18,6 +18,7 @@ export interface Violation {
 
 export interface DesignFile {
   filename: string
+  file_path: string
   title: string
   screen_type: string
   html: string
@@ -42,7 +43,9 @@ export function isSessionDesignFileChange(file: string, sessionCwd: string): boo
 
   return (
     relativePath.endsWith(".html") &&
-    (relativePath.startsWith("screens/") || !relativePath.includes("/"))
+    (relativePath.startsWith(".designs/") ||
+      relativePath.startsWith("screens/") ||
+      !relativePath.includes("/"))
   )
 }
 

--- a/apps/desktop/src/hooks/use-projects.ts
+++ b/apps/desktop/src/hooks/use-projects.ts
@@ -1,0 +1,107 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import type { Platform, ProjectMeta } from "@dilag/desktop-bridge"
+import { bridge } from "@/lib/bridge"
+
+export const projectKeys = {
+  all: ["projects"] as const,
+  list: () => [...projectKeys.all, "list"] as const,
+  legacyNotice: () => [...projectKeys.all, "legacy-notice"] as const,
+}
+
+export function useProjectsList() {
+  return useQuery({
+    queryKey: projectKeys.list(),
+    queryFn: () => bridge.projects.list(),
+    staleTime: 30_000,
+  })
+}
+
+export function useLegacySessionsNotice(enabled: boolean) {
+  return useQuery({
+    queryKey: projectKeys.legacyNotice(),
+    queryFn: () => bridge.projects.getLegacyNotice(),
+    enabled,
+  })
+}
+
+export function getDefaultProject(projects: ProjectMeta[]): ProjectMeta | null {
+  if (projects.length === 0) return null
+  const sorted = [...projects].sort(
+    (a, b) => new Date(b.last_opened_at).getTime() - new Date(a.last_opened_at).getTime(),
+  )
+  return sorted.find((project) => project.pinned) ?? sorted[0] ?? null
+}
+
+export function useProjectMutations() {
+  const queryClient = useQueryClient()
+
+  const upsertProjectInCache = (project: ProjectMeta) => {
+    queryClient.setQueryData<ProjectMeta[]>(projectKeys.list(), (old) => {
+      const current = old ?? []
+      const exists = current.some((item) => item.id === project.id)
+      const next = exists
+        ? current.map((item) => (item.id === project.id ? project : item))
+        : [project, ...current]
+      return [...next].sort(
+        (a, b) =>
+          Number(b.pinned) - Number(a.pinned) ||
+          new Date(b.last_opened_at).getTime() - new Date(a.last_opened_at).getTime(),
+      )
+    })
+  }
+
+  const createProject = useMutation({
+    mutationFn: (args: { name: string; platform?: Platform }) => bridge.projects.create(args),
+    onSuccess: upsertProjectInCache,
+  })
+
+  const addExistingProject = useMutation({
+    mutationFn: (args: { path: string; platform?: Platform }) => bridge.projects.addExisting(args),
+    onSuccess: upsertProjectInCache,
+  })
+
+  const updateProject = useMutation({
+    mutationFn: (args: {
+      id: string
+      updates: Partial<Pick<ProjectMeta, "name" | "platform" | "pinned" | "expanded">>
+    }) => bridge.projects.update(args),
+    onSuccess: upsertProjectInCache,
+  })
+
+  const removeProject = useMutation({
+    mutationFn: async (id: string) => {
+      await bridge.projects.remove({ id })
+      return id
+    },
+    onSuccess: (id) => {
+      queryClient.setQueryData<ProjectMeta[]>(
+        projectKeys.list(),
+        (old) => old?.filter((project) => project.id !== id) ?? [],
+      )
+    },
+  })
+
+  const touchProject = useMutation({
+    mutationFn: (id: string) => bridge.projects.touch({ id }),
+    onSuccess: upsertProjectInCache,
+  })
+
+  const dismissLegacyNotice = useMutation({
+    mutationFn: () => bridge.projects.dismissLegacyNotice(),
+    onSuccess: () => {
+      queryClient.setQueryData(projectKeys.legacyNotice(), {
+        hasLegacySessions: true,
+        dismissed: true,
+      })
+    },
+  })
+
+  return {
+    createProject: createProject.mutateAsync,
+    addExistingProject: addExistingProject.mutateAsync,
+    updateProject: updateProject.mutateAsync,
+    removeProject: removeProject.mutateAsync,
+    touchProject: touchProject.mutateAsync,
+    dismissLegacyNotice: dismissLegacyNotice.mutateAsync,
+  }
+}

--- a/apps/desktop/src/hooks/use-session-data.ts
+++ b/apps/desktop/src/hooks/use-session-data.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
-import type { SessionMeta } from "@/context/session-store"
+import type { Platform, SessionMeta } from "@/context/session-store"
 import { bridge } from "@/lib/bridge"
 
 /**
@@ -15,7 +15,31 @@ export const sessionKeys = {
 
 // Desktop bridge calls for local session management.
 async function loadSessionsMetadata(): Promise<SessionMeta[]> {
-  return bridge.sessions.loadMeta() as Promise<SessionMeta[]>
+  const projects = await bridge.projects.list()
+  const projectSessions = await Promise.all(
+    projects.map(async (project) => {
+      const sessions = await bridge.agent.listSessions({ directory: project.path }).catch(() => [])
+      return sessions.map((session): SessionMeta => {
+        const name = session.name || session.first_message || "New chat"
+        return {
+          id: session.id,
+          name,
+          created_at: session.created_at,
+          updated_at: session.updated_at,
+          cwd: project.path,
+          platform: project.platform as Platform,
+          favorite: project.pinned,
+          projectId: project.id,
+        }
+      })
+    }),
+  )
+  return projectSessions.flat().sort((a, b) => {
+    return (
+      new Date(a.updated_at ?? a.created_at).getTime() -
+      new Date(b.updated_at ?? b.created_at).getTime()
+    )
+  })
 }
 
 async function saveSessionMetadata(session: SessionMeta): Promise<void> {

--- a/apps/desktop/src/hooks/use-sessions.test.ts
+++ b/apps/desktop/src/hooks/use-sessions.test.ts
@@ -104,13 +104,15 @@ describe("use-sessions", () => {
         await result.current.sendMessage("Hello")
       })
 
-      expect(mockPrompt).toHaveBeenCalledWith({
-        sessionID: "session-1",
-        directory: "/mock/cwd/1",
-        text: "/skill:web-design Hello",
-        images: [],
-        model: null,
-      })
+      expect(mockPrompt).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionID: "session-1",
+          directory: "/mock/cwd/1",
+          text: "/skill:dilag-web-design Hello",
+          images: [],
+          model: null,
+        }),
+      )
     })
 
     it("uses the selected model when one exists", async () => {
@@ -164,7 +166,7 @@ describe("use-sessions", () => {
 
       expect(mockPrompt).toHaveBeenCalledWith(
         expect.objectContaining({
-          text: "/skill:web-design Hello with image",
+          text: "/skill:dilag-web-design Hello with image",
           images: [{ type: "image", mimeType: "image/png", data: "abc" }],
         }),
       )

--- a/apps/desktop/src/hooks/use-sessions.ts
+++ b/apps/desktop/src/hooks/use-sessions.ts
@@ -16,7 +16,6 @@ import {
   useSessionsList,
   useCurrentSession,
   useSessionMutations,
-  createSessionDir,
   sessionKeys,
 } from "@/hooks/use-session-data"
 import { useGlobalEvents, useConnectionStatus, type Event } from "@/context/global-events"
@@ -27,6 +26,7 @@ import { bridge } from "@/lib/bridge"
 import type {
   AgentImageContent as BridgeAgentImageContent,
   AgentMessage as BridgeAgentMessage,
+  ProjectMeta,
 } from "@dilag/desktop-bridge"
 import type { FileUIPart } from "ai"
 import { formatElementWithAncestry, minifyHtml } from "@/lib/html-utils"
@@ -85,7 +85,6 @@ export function useSessions() {
 
   // React Query mutations
   const {
-    createSession: saveSession,
     updateSession: saveSessionUpdate,
     deleteSession: removeSession,
     toggleFavorite: toggleSessionFavorite,
@@ -257,29 +256,38 @@ export function useSessions() {
             updates.updated_at = new Date(info.time.updated).toISOString()
           }
 
-          // Only save if there are updates
+          // Pi SDK is the source of truth for project sessions. Keep legacy
+          // session metadata in sync only for old sessions without a project.
           if (Object.keys(updates).length > 0) {
-            await saveSessionUpdate({
-              id: currentSessionId,
-              updates,
-            })
+            if (currentSession?.projectId) {
+              queryClient.invalidateQueries({ queryKey: sessionKeys.list() })
+            } else {
+              await saveSessionUpdate({
+                id: currentSessionId,
+                updates,
+              })
+            }
           }
         }
       }
     })
 
     return unsubscribe
-  }, [currentSessionId, subscribeToSession, saveSessionUpdate])
+  }, [currentSessionId, subscribeToSession, saveSessionUpdate, currentSession, queryClient])
 
   const createSession = useCallback(
     async (name?: string, platform: "web" | "mobile" = "web"): Promise<string | null> => {
       try {
         setError(null)
 
-        const dirId = crypto.randomUUID()
-        const cwd = await createSessionDir(dirId)
+        const projects = await bridge.projects.list()
+        const sortedProjects = [...projects].sort(
+          (a, b) => new Date(b.last_opened_at).getTime() - new Date(a.last_opened_at).getTime(),
+        )
+        const project = sortedProjects.find((item) => item.pinned) ?? sortedProjects[0]
+        if (!project) throw new Error("Create a project before starting a design")
+        const cwd = project.path
 
-        // No project initialization needed - AI generates HTML screens directly
         const response = await bridge.agent.createSession({ directory: cwd })
         const sessionId = response.id
 
@@ -291,11 +299,15 @@ export function useSessions() {
           created_at: now,
           updated_at: now,
           cwd,
-          platform,
+          platform: project.platform ?? platform,
+          projectId: project.id,
         }
 
-        // Save to the desktop bridge and update React Query cache.
-        await saveSession(sessionMeta)
+        // Update React Query cache optimistically. Pi SDK owns persistence.
+        queryClient.setQueryData<SessionMeta[]>(sessionKeys.list(), (old) =>
+          old ? [...old, sessionMeta] : [sessionMeta],
+        )
+        queryClient.invalidateQueries({ queryKey: sessionKeys.list() })
 
         // Update Zustand client state
         setCurrentSessionId(sessionId)
@@ -308,7 +320,39 @@ export function useSessions() {
         return null
       }
     },
-    [sessions.length, setError, setCurrentSessionId, setMessages, saveSession],
+    [sessions.length, setError, setCurrentSessionId, setMessages, queryClient],
+  )
+
+  const createSessionInProject = useCallback(
+    async (project: ProjectMeta, name?: string): Promise<string | null> => {
+      try {
+        setError(null)
+        const response = await bridge.agent.createSession({ directory: project.path })
+        const now = new Date().toISOString()
+        const sessionMeta: SessionMeta = {
+          id: response.id,
+          name: name ?? "New chat",
+          created_at: now,
+          updated_at: now,
+          cwd: project.path,
+          platform: project.platform,
+          projectId: project.id,
+          favorite: project.pinned,
+        }
+        queryClient.setQueryData<SessionMeta[]>(sessionKeys.list(), (old) =>
+          old ? [...old, sessionMeta] : [sessionMeta],
+        )
+        setCurrentSessionId(response.id)
+        setMessages(response.id, [])
+        queryClient.invalidateQueries({ queryKey: sessionKeys.list() })
+        return response.id
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to create chat")
+        console.error("Failed to create project chat:", err)
+        return null
+      }
+    },
+    [queryClient, setCurrentSessionId, setError, setMessages],
   )
 
   const selectSession = useCallback(
@@ -325,15 +369,25 @@ export function useSessions() {
   const deleteSession = useCallback(
     async (sessionId: string) => {
       try {
+        const session = sessions.find((item) => item.id === sessionId)
+
         // Delete from the agent runtime (may not exist if never sent a message)
         await withErrorHandler(
-          () => bridge.agent.deleteSession({ sessionID: sessionId }),
+          () => bridge.agent.deleteSession({ sessionID: sessionId, directory: session?.cwd }),
           `deleteSession(${sessionId})`,
           undefined, // Continue on error - session may not exist in the runtime
         )
 
-        // Delete local metadata (React Query mutation)
-        await removeSession(sessionId)
+        if (session?.projectId) {
+          queryClient.setQueryData<SessionMeta[]>(
+            sessionKeys.list(),
+            (old) => old?.filter((item) => item.id !== sessionId) ?? [],
+          )
+          queryClient.invalidateQueries({ queryKey: sessionKeys.list() })
+        } else {
+          // Delete legacy local metadata (React Query mutation)
+          await removeSession(sessionId)
+        }
 
         // Clear Zustand real-time data
         clearSessionData(sessionId)
@@ -342,7 +396,7 @@ export function useSessions() {
         console.error("Failed to delete session:", err)
       }
     },
-    [removeSession, clearSessionData, setError],
+    [sessions, queryClient, removeSession, clearSessionData, setError],
   )
 
   const stopSession = useCallback(async () => {
@@ -439,11 +493,8 @@ export function useSessions() {
     try {
       setError(null)
 
-      // Create a new session directory
-      const dirId = crypto.randomUUID()
-      const cwd = await createSessionDir(dirId)
-
-      // Create session in the agent runtime with the new directory
+      // Create a new chat in the same project folder.
+      const cwd = currentSession.cwd
       const response = await bridge.agent.createSession({ directory: cwd })
       const newSessionId = response.id
 
@@ -463,10 +514,14 @@ export function useSessions() {
         cwd,
         parentID: currentSessionId,
         platform: currentSession.platform,
+        projectId: currentSession.projectId,
+        favorite: currentSession.favorite,
       }
 
-      // Save to the desktop bridge and update React Query cache.
-      await saveSession(sessionMeta)
+      queryClient.setQueryData<SessionMeta[]>(sessionKeys.list(), (old) =>
+        old ? [...old, sessionMeta] : [sessionMeta],
+      )
+      queryClient.invalidateQueries({ queryKey: sessionKeys.list() })
 
       // Switch to the new session
       setCurrentSessionId(newSessionId)
@@ -478,7 +533,7 @@ export function useSessions() {
       console.error("Failed to fork session with designs:", err)
       return null
     }
-  }, [currentSessionId, currentSession, saveSession, setCurrentSessionId, setMessages, setError])
+  }, [currentSessionId, currentSession, queryClient, setCurrentSessionId, setMessages, setError])
 
   const sendMessage = useCallback(
     async (content: string, files?: FileUIPart[]) => {
@@ -526,7 +581,7 @@ export function useSessions() {
         // On first message, prepend skill instruction
         const platform = currentSession.platform ?? "web"
         const isFirstMessage = messages.length === 0
-        const skillHint = isFirstMessage ? `/skill:${platform}-design ` : ""
+        const skillHint = isFirstMessage ? `/skill:dilag-${platform}-design ` : ""
 
         let promptText = skillHint + content
 
@@ -677,6 +732,7 @@ export function useSessions() {
     sessionStatus,
     connectionStatus,
     createSession,
+    createSessionInProject,
     selectSession,
     deleteSession,
     sendMessage,

--- a/apps/desktop/src/routeTree.gen.ts
+++ b/apps/desktop/src/routeTree.gen.ts
@@ -14,6 +14,8 @@ import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as ProjectsRouteImport } from './routes/projects'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as StudioSessionIdRouteImport } from './routes/studio.$sessionId'
+import { Route as ProjectProjectIdRouteImport } from './routes/project.$projectId'
+import { Route as ProjectProjectIdSessionSessionIdRouteImport } from './routes/project.$projectId.session.$sessionId'
 
 const SkillsRoute = SkillsRouteImport.update({
   id: '/skills',
@@ -40,20 +42,35 @@ const StudioSessionIdRoute = StudioSessionIdRouteImport.update({
   path: '/studio/$sessionId',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ProjectProjectIdRoute = ProjectProjectIdRouteImport.update({
+  id: '/project/$projectId',
+  path: '/project/$projectId',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ProjectProjectIdSessionSessionIdRoute =
+  ProjectProjectIdSessionSessionIdRouteImport.update({
+    id: '/session/$sessionId',
+    path: '/session/$sessionId',
+    getParentRoute: () => ProjectProjectIdRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/projects': typeof ProjectsRoute
   '/settings': typeof SettingsRoute
   '/skills': typeof SkillsRoute
+  '/project/$projectId': typeof ProjectProjectIdRouteWithChildren
   '/studio/$sessionId': typeof StudioSessionIdRoute
+  '/project/$projectId/session/$sessionId': typeof ProjectProjectIdSessionSessionIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/projects': typeof ProjectsRoute
   '/settings': typeof SettingsRoute
   '/skills': typeof SkillsRoute
+  '/project/$projectId': typeof ProjectProjectIdRouteWithChildren
   '/studio/$sessionId': typeof StudioSessionIdRoute
+  '/project/$projectId/session/$sessionId': typeof ProjectProjectIdSessionSessionIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -61,20 +78,38 @@ export interface FileRoutesById {
   '/projects': typeof ProjectsRoute
   '/settings': typeof SettingsRoute
   '/skills': typeof SkillsRoute
+  '/project/$projectId': typeof ProjectProjectIdRouteWithChildren
   '/studio/$sessionId': typeof StudioSessionIdRoute
+  '/project/$projectId/session/$sessionId': typeof ProjectProjectIdSessionSessionIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/projects' | '/settings' | '/skills' | '/studio/$sessionId'
+  fullPaths:
+    | '/'
+    | '/projects'
+    | '/settings'
+    | '/skills'
+    | '/project/$projectId'
+    | '/studio/$sessionId'
+    | '/project/$projectId/session/$sessionId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/projects' | '/settings' | '/skills' | '/studio/$sessionId'
+  to:
+    | '/'
+    | '/projects'
+    | '/settings'
+    | '/skills'
+    | '/project/$projectId'
+    | '/studio/$sessionId'
+    | '/project/$projectId/session/$sessionId'
   id:
     | '__root__'
     | '/'
     | '/projects'
     | '/settings'
     | '/skills'
+    | '/project/$projectId'
     | '/studio/$sessionId'
+    | '/project/$projectId/session/$sessionId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -82,6 +117,7 @@ export interface RootRouteChildren {
   ProjectsRoute: typeof ProjectsRoute
   SettingsRoute: typeof SettingsRoute
   SkillsRoute: typeof SkillsRoute
+  ProjectProjectIdRoute: typeof ProjectProjectIdRouteWithChildren
   StudioSessionIdRoute: typeof StudioSessionIdRoute
 }
 
@@ -122,14 +158,40 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof StudioSessionIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/project/$projectId': {
+      id: '/project/$projectId'
+      path: '/project/$projectId'
+      fullPath: '/project/$projectId'
+      preLoaderRoute: typeof ProjectProjectIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/project/$projectId/session/$sessionId': {
+      id: '/project/$projectId/session/$sessionId'
+      path: '/session/$sessionId'
+      fullPath: '/project/$projectId/session/$sessionId'
+      preLoaderRoute: typeof ProjectProjectIdSessionSessionIdRouteImport
+      parentRoute: typeof ProjectProjectIdRoute
+    }
   }
 }
+
+interface ProjectProjectIdRouteChildren {
+  ProjectProjectIdSessionSessionIdRoute: typeof ProjectProjectIdSessionSessionIdRoute
+}
+
+const ProjectProjectIdRouteChildren: ProjectProjectIdRouteChildren = {
+  ProjectProjectIdSessionSessionIdRoute: ProjectProjectIdSessionSessionIdRoute,
+}
+
+const ProjectProjectIdRouteWithChildren =
+  ProjectProjectIdRoute._addFileChildren(ProjectProjectIdRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ProjectsRoute: ProjectsRoute,
   SettingsRoute: SettingsRoute,
   SkillsRoute: SkillsRoute,
+  ProjectProjectIdRoute: ProjectProjectIdRouteWithChildren,
   StudioSessionIdRoute: StudioSessionIdRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/desktop/src/routes/__root.tsx
+++ b/apps/desktop/src/routes/__root.tsx
@@ -2,6 +2,7 @@ import { createRootRoute, Outlet } from "@tanstack/react-router"
 import { NuqsAdapter } from "nuqs/adapters/tanstack-router"
 import { SidebarProvider, SidebarInset } from "@dilag/ui/sidebar"
 import { AppSidebar } from "@/components/blocks/layout/app-sidebar"
+import { AutoCollapseSidebar } from "@/components/blocks/layout/auto-collapse-sidebar"
 import { AppProviders } from "@/components/app-providers"
 import { useZoom } from "@/hooks/use-zoom"
 
@@ -21,6 +22,7 @@ function RootLayout() {
     <AppProviders>
       <NuqsAdapter>
         <SidebarProvider defaultOpen={true}>
+          <AutoCollapseSidebar />
           <AppSidebar />
           <SidebarInset className="h-svh">
             <Outlet />

--- a/apps/desktop/src/routes/index.tsx
+++ b/apps/desktop/src/routes/index.tsx
@@ -1,223 +1,159 @@
-import {
-  PromptInput,
-  PromptInputAddAttachmentButton,
-  PromptInputAttachment,
-  PromptInputAttachments,
-  PromptInputScreenReferences,
-  PromptInputScreenReference,
-  PromptInputBody,
-  PromptInputFooter,
-  PromptInputProvider,
-  PromptInputSubmit,
-  PromptInputTextarea,
-  PromptInputTools,
-  usePromptInputController,
-} from "@/components/ai-elements/prompt-input"
 import { PageHeader } from "@/components/blocks/layout/page-header"
-import { ModelSelectorButton } from "@/components/blocks/selectors/model-selector-button"
-import { AgentSelectorButton } from "@/components/blocks/selectors/agent-selector-button"
-import { ThinkingModeSelector } from "@/components/blocks/selectors/thinking-mode-selector"
-import { useSessions } from "@/hooks/use-sessions"
-import { type Platform } from "@/context/session-store"
-import { cn } from "@/lib/utils"
-import { ArrowUp, Monitor, Smartphone } from "@solar-icons/react"
+import {
+  getDefaultProject,
+  useLegacySessionsNotice,
+  useProjectMutations,
+  useProjectsList,
+} from "@/hooks/use-projects"
+import { bridge } from "@/lib/bridge"
+import { AddCircle, AddSquare, History } from "@solar-icons/react"
+import { Button } from "@dilag/ui/button"
+import { Input } from "@dilag/ui/input"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
-import { parseAsStringLiteral, useQueryState } from "nuqs"
-
-const SUGGESTIONS = [
-  "A habit tracking app",
-  "A recipe finder with search",
-  "A workout timer",
-  "A notes app with markdown",
-]
+import { useEffect, useState } from "react"
 
 export const Route = createFileRoute("/")({
-  component: LandingPage,
+  component: HomePage,
 })
 
-function LandingPage() {
+function HomePage() {
   const navigate = useNavigate()
-  const { createSession, isServerReady } = useSessions()
-  const [platform, setPlatform] = useQueryState(
-    "platform",
-    parseAsStringLiteral(["web", "mobile"] as const).withDefault("web"),
-  )
+  const [projectName, setProjectName] = useState("")
+  const { data: projects = [] } = useProjectsList()
+  const { createProject, addExistingProject, dismissLegacyNotice } = useProjectMutations()
+  const { data: legacyNotice } = useLegacySessionsNotice(projects.length === 0)
 
-  const handleSubmit = async (text: string, files?: import("ai").FileUIPart[]) => {
-    if (!text.trim() && (!files || files.length === 0)) return
-    localStorage.setItem("dilag-initial-prompt", text)
-    localStorage.setItem("dilag-initial-platform", platform)
-    if (files && files.length > 0) {
-      localStorage.setItem("dilag-initial-files", JSON.stringify(files))
-    } else {
-      localStorage.removeItem("dilag-initial-files")
+  useEffect(() => {
+    const project = getDefaultProject(projects)
+    if (project) {
+      navigate({ to: "/project/$projectId", params: { projectId: project.id }, replace: true })
     }
-    const sessionId = await createSession(undefined, platform)
-    if (sessionId) {
-      navigate({ to: "/studio/$sessionId", params: { sessionId } })
-    }
+  }, [navigate, projects])
+
+  const handleStartFromScratch = async () => {
+    const name = projectName.trim()
+    if (!name) return
+    const project = await createProject({ name })
+    navigate({ to: "/project/$projectId", params: { projectId: project.id } })
+  }
+
+  const handleUseExistingFolder = async () => {
+    const folder = await bridge.dialog.openDirectory()
+    if (!folder) return
+    const project = await addExistingProject({ path: folder })
+    navigate({ to: "/project/$projectId", params: { projectId: project.id } })
   }
 
   return (
     <div className="h-full flex flex-col bg-background relative overflow-hidden">
       <PageHeader />
-      <div
-        className="absolute inset-0 pointer-events-none opacity-40 dark:opacity-20"
-        style={{
-          background: `
-            radial-gradient(ellipse 80% 50% at 50% -20%, oklch(0.7 0.1 255 / 15%), transparent),
-            radial-gradient(ellipse 60% 40% at 100% 100%, oklch(0.7 0.08 200 / 10%), transparent)
-          `,
-        }}
-      />
-
-      {/* Connection status indicator */}
-      {!isServerReady && (
-        <div className="absolute top-2 right-3 flex items-center gap-1.5 z-10">
-          <div className="size-1.5 rounded-full bg-amber-500/80" />
-          <span className="text-[10px] text-muted-foreground">connecting</span>
-        </div>
-      )}
-
-      <main className="relative flex-1 flex flex-col overflow-auto">
-        <div className="flex-1 flex items-center justify-center px-6 py-16">
-          <div className="w-full max-w-2xl">
-            <div
-              className="animate-in fade-in slide-in-from-bottom-6 duration-700 text-center mb-10"
-              style={{ animationFillMode: "backwards" }}
-            >
-              <h1 className="text-[42px] md:text-[52px] font-medium leading-[1.1] tracking-[-0.03em] whitespace-nowrap text-balance">
-                <span className="text-foreground">What would you like</span>{" "}
-                <span className="text-muted-foreground/50">to design?</span>
-              </h1>
-            </div>
-
-            <div
-              className="animate-in fade-in slide-in-from-bottom-6 duration-700"
-              style={{
-                animationDelay: "100ms",
-                animationFillMode: "backwards",
-              }}
-            >
-              <PlatformToggle value={platform} onChange={setPlatform} />
-
-              <PromptInputProvider>
-                <ComposerInput onSubmit={handleSubmit} disabled={!isServerReady} />
-              </PromptInputProvider>
-
-              <div className="flex justify-center gap-2 mt-8">
-                {SUGGESTIONS.map((suggestion) => (
-                  <button
-                    key={suggestion}
-                    onClick={() => handleSubmit(suggestion)}
-                    disabled={!isServerReady}
-                    className="px-4 py-1.5 text-[13px] text-muted-foreground hover:text-foreground border border-border/60 hover:border-border rounded-full transition-colors whitespace-nowrap disabled:opacity-40 disabled:cursor-not-allowed"
-                  >
-                    {suggestion}
-                  </button>
-                ))}
+      <main className="flex-1 overflow-auto px-8 py-10">
+        <div className="mx-auto flex min-h-full w-full max-w-5xl items-center">
+          <div className="grid w-full gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
+            <section className="space-y-5">
+              <div className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-muted/30 px-3 py-1 text-xs text-muted-foreground">
+                <span className="size-1.5 rounded-full bg-primary" />
+                Projects are local folders
               </div>
-            </div>
+              <div className="space-y-3">
+                <h1 className="max-w-md text-[44px] font-medium leading-[0.98] tracking-[-0.045em]">
+                  Choose where your designs live.
+                </h1>
+                <p className="max-w-sm text-sm leading-6 text-muted-foreground">
+                  Create a fresh workspace or open an existing folder. Chats are grouped under the
+                  Project, and generated screens are saved as
+                  <code className="mx-1 rounded-md border border-border/60 bg-muted/50 px-1.5 py-0.5 text-xs">
+                    .designs/*.html
+                  </code>
+                  .
+                </p>
+              </div>
+            </section>
+
+            <section className="space-y-3">
+              <div className="rounded-3xl border border-border/70 bg-card/70 p-2 shadow-2xl shadow-black/20 backdrop-blur">
+                <div className="grid gap-2 md:grid-cols-2">
+                  <form
+                    onSubmit={(event) => {
+                      event.preventDefault()
+                      handleStartFromScratch()
+                    }}
+                    className="flex min-h-[220px] flex-col rounded-2xl border border-border/70 bg-background/70 p-5"
+                  >
+                    <div className="mb-5 flex size-10 items-center justify-center rounded-xl bg-primary text-primary-foreground">
+                      <AddCircle size={18} />
+                    </div>
+                    <div className="space-y-1.5">
+                      <h2 className="text-base font-medium">Start from scratch</h2>
+                      <p className="text-sm leading-5 text-muted-foreground">
+                        Creates a new folder under
+                        <code className="mx-1 rounded bg-muted px-1 py-0.5 text-xs">~/dilag</code>
+                        and opens an empty composer.
+                      </p>
+                    </div>
+                    <div className="mt-auto space-y-2 pt-5">
+                      <Input
+                        value={projectName}
+                        onChange={(event) => setProjectName(event.target.value)}
+                        placeholder="Project name"
+                        className="h-9"
+                      />
+                      <Button type="submit" className="w-full" disabled={!projectName.trim()}>
+                        Create project
+                      </Button>
+                    </div>
+                  </form>
+
+                  <button
+                    onClick={handleUseExistingFolder}
+                    className="group flex min-h-[220px] flex-col rounded-2xl border border-border/70 bg-muted/20 p-5 text-left transition-colors hover:bg-muted/35"
+                  >
+                    <div className="mb-5 flex size-10 items-center justify-center rounded-xl border border-border bg-background transition-transform group-hover:-translate-y-0.5">
+                      <AddSquare size={18} />
+                    </div>
+                    <div className="space-y-1.5">
+                      <h2 className="text-base font-medium">Use an existing folder</h2>
+                      <p className="text-sm leading-5 text-muted-foreground">
+                        Pick any local folder and Dilag will list Pi chats for that Project.
+                      </p>
+                    </div>
+                    <div className="mt-auto pt-5 text-sm font-medium text-foreground">
+                      Open folder →
+                    </div>
+                  </button>
+                </div>
+              </div>
+
+              {legacyNotice?.hasLegacySessions && !legacyNotice.dismissed && (
+                <div className="rounded-2xl border border-border/70 bg-muted/20 p-4">
+                  <div className="flex gap-3">
+                    <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg bg-background">
+                      <History size={16} />
+                    </div>
+                    <div className="min-w-0 flex-1 space-y-2">
+                      <div>
+                        <h2 className="text-sm font-medium">Old sessions found</h2>
+                        <p className="mt-1 text-sm leading-5 text-muted-foreground">
+                          Your previous Dilag sessions are still on this device. Add any session
+                          folder as a Project to keep working with it.
+                        </p>
+                      </div>
+                      <div className="flex gap-2">
+                        <Button size="sm" variant="secondary" onClick={handleUseExistingFolder}>
+                          Use an existing folder
+                        </Button>
+                        <Button size="sm" variant="ghost" onClick={() => dismissLegacyNotice()}>
+                          Dismiss
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </section>
           </div>
         </div>
       </main>
-    </div>
-  )
-}
-
-function ComposerInput({
-  onSubmit,
-  disabled,
-}: {
-  onSubmit: (text: string, files?: import("ai").FileUIPart[]) => void
-  disabled: boolean
-}) {
-  const { textInput } = usePromptInputController()
-  const hasInput = textInput.value.trim().length > 0
-
-  return (
-    <PromptInput
-      onSubmit={async ({ text, files }) => onSubmit(text, files)}
-      className="border border-border bg-card transition-colors duration-200 focus-within:border-primary/50"
-    >
-      <PromptInputAttachments>
-        {(attachment) => <PromptInputAttachment data={attachment} />}
-      </PromptInputAttachments>
-      <PromptInputScreenReferences className="px-3 pt-2">
-        {(ref) => <PromptInputScreenReference data={ref} />}
-      </PromptInputScreenReferences>
-      <PromptInputBody>
-        <PromptInputTextarea
-          placeholder="Describe your app..."
-          disabled={disabled}
-          className="min-h-[100px] max-h-[200px]"
-        />
-      </PromptInputBody>
-      <PromptInputFooter className="border-t-0">
-        {/* Left side - agent selector, model selector, thinking mode */}
-        <PromptInputTools>
-          <AgentSelectorButton />
-          <ModelSelectorButton />
-          <ThinkingModeSelector />
-        </PromptInputTools>
-
-        <div className="flex-1" />
-
-        {/* Right side - attachment menu + submit */}
-        <div className="flex items-center gap-1">
-          <PromptInputAddAttachmentButton />
-          <PromptInputSubmit
-            disabled={!hasInput || disabled}
-            className={cn(
-              "size-9 rounded-xl transition-all duration-200",
-              hasInput && !disabled
-                ? "bg-primary text-primary-foreground shadow-lg shadow-primary/25"
-                : "bg-muted text-muted-foreground",
-            )}
-          >
-            <ArrowUp size={16} />
-          </PromptInputSubmit>
-        </div>
-      </PromptInputFooter>
-    </PromptInput>
-  )
-}
-
-function PlatformToggle({
-  value,
-  onChange,
-}: {
-  value: Platform
-  onChange: (platform: Platform) => void
-}) {
-  return (
-    <div className="flex justify-center mb-6">
-      <div className="inline-flex items-center gap-1 p-1 rounded-lg bg-muted/50 border border-border/30">
-        <button
-          onClick={() => onChange("web")}
-          className={cn(
-            "flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-all duration-200",
-            value === "web"
-              ? "bg-background text-foreground shadow-sm"
-              : "text-muted-foreground hover:text-foreground",
-          )}
-        >
-          <Monitor size={16} />
-          Web
-        </button>
-        <button
-          onClick={() => onChange("mobile")}
-          className={cn(
-            "flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-all duration-200",
-            value === "mobile"
-              ? "bg-background text-foreground shadow-sm"
-              : "text-muted-foreground hover:text-foreground",
-          )}
-        >
-          <Smartphone size={16} />
-          Mobile
-        </button>
-      </div>
     </div>
   )
 }

--- a/apps/desktop/src/routes/project.$projectId.session.$sessionId.tsx
+++ b/apps/desktop/src/routes/project.$projectId.session.$sessionId.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, useParams } from "@tanstack/react-router"
+import { StudioPageContent } from "./studio.$sessionId"
+
+export const Route = createFileRoute("/project/$projectId/session/$sessionId")({
+  component: ProjectSessionPage,
+})
+
+function ProjectSessionPage() {
+  const { projectId, sessionId } = useParams({ from: "/project/$projectId/session/$sessionId" })
+  return <StudioPageContent projectId={projectId} sessionId={sessionId} />
+}

--- a/apps/desktop/src/routes/project.$projectId.tsx
+++ b/apps/desktop/src/routes/project.$projectId.tsx
@@ -1,0 +1,183 @@
+import {
+  PromptInput,
+  PromptInputAddAttachmentButton,
+  PromptInputAttachment,
+  PromptInputAttachments,
+  PromptInputBody,
+  PromptInputFooter,
+  PromptInputProvider,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputTools,
+  usePromptInputController,
+} from "@/components/ai-elements/prompt-input"
+import { PageHeader } from "@/components/blocks/layout/page-header"
+import { AgentSelectorButton } from "@/components/blocks/selectors/agent-selector-button"
+import { ModelSelectorButton } from "@/components/blocks/selectors/model-selector-button"
+import { ThinkingModeSelector } from "@/components/blocks/selectors/thinking-mode-selector"
+import { useProjectMutations, useProjectsList } from "@/hooks/use-projects"
+import { useSessions } from "@/hooks/use-sessions"
+import { cn } from "@/lib/utils"
+import { ArrowUp, Monitor, Smartphone } from "@solar-icons/react"
+import { createFileRoute, useNavigate, useParams } from "@tanstack/react-router"
+import type { FileUIPart } from "ai"
+
+export const Route = createFileRoute("/project/$projectId")({
+  component: ProjectComposerPage,
+})
+
+function ProjectComposerPage() {
+  const { projectId } = useParams({ from: "/project/$projectId" })
+  const navigate = useNavigate()
+  const { data: projects = [] } = useProjectsList()
+  const { updateProject, touchProject } = useProjectMutations()
+  const { createSessionInProject, isServerReady } = useSessions()
+  const project = projects.find((item) => item.id === projectId)
+
+  const handleSubmit = async (text: string, files?: FileUIPart[]) => {
+    if (!project || (!text.trim() && (!files || files.length === 0))) return
+    localStorage.setItem("dilag-initial-prompt", text)
+    localStorage.setItem("dilag-initial-platform", project.platform)
+    if (files && files.length > 0) {
+      localStorage.setItem("dilag-initial-files", JSON.stringify(files))
+    } else {
+      localStorage.removeItem("dilag-initial-files")
+    }
+
+    await touchProject(project.id)
+    const sessionId = await createSessionInProject(project)
+    if (sessionId) {
+      navigate({
+        to: "/project/$projectId/session/$sessionId",
+        params: { projectId: project.id, sessionId },
+      })
+    }
+  }
+
+  if (!project) {
+    return (
+      <div className="h-full flex flex-col bg-background">
+        <PageHeader />
+        <main className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
+          Project not found
+        </main>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col bg-background relative overflow-hidden">
+      <PageHeader />
+      <main className="relative flex-1 flex flex-col overflow-auto">
+        <div className="flex-1 flex items-center justify-center px-6 py-16">
+          <div className="w-full max-w-2xl">
+            <div className="text-center mb-10">
+              <h1 className="text-[34px] md:text-[40px] font-medium leading-[1.1] tracking-[-0.03em] text-balance">
+                What should we design in {project.name}?
+              </h1>
+            </div>
+
+            <PlatformToggle
+              value={project.platform}
+              onChange={(platform) => updateProject({ id: project.id, updates: { platform } })}
+            />
+
+            <PromptInputProvider>
+              <ComposerInput onSubmit={handleSubmit} disabled={!isServerReady} />
+            </PromptInputProvider>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}
+
+function ComposerInput({
+  onSubmit,
+  disabled,
+}: {
+  onSubmit: (text: string, files?: FileUIPart[]) => void
+  disabled: boolean
+}) {
+  const { textInput } = usePromptInputController()
+  const hasInput = textInput.value.trim().length > 0
+
+  return (
+    <PromptInput
+      onSubmit={async ({ text, files }) => onSubmit(text, files)}
+      className="border border-border bg-card transition-colors duration-200 focus-within:border-primary/50"
+    >
+      <PromptInputAttachments>
+        {(attachment) => <PromptInputAttachment data={attachment} />}
+      </PromptInputAttachments>
+      <PromptInputBody>
+        <PromptInputTextarea
+          placeholder="Describe your app..."
+          disabled={disabled}
+          className="min-h-[100px] max-h-[200px]"
+        />
+      </PromptInputBody>
+      <PromptInputFooter className="border-t-0">
+        <PromptInputTools>
+          <AgentSelectorButton />
+          <ModelSelectorButton />
+          <ThinkingModeSelector />
+        </PromptInputTools>
+        <div className="flex-1" />
+        <div className="flex items-center gap-1">
+          <PromptInputAddAttachmentButton />
+          <PromptInputSubmit
+            disabled={!hasInput || disabled}
+            className={cn(
+              "size-9 rounded-xl transition-all duration-200",
+              hasInput && !disabled
+                ? "bg-primary text-primary-foreground shadow-lg shadow-primary/25"
+                : "bg-muted text-muted-foreground",
+            )}
+          >
+            <ArrowUp size={16} />
+          </PromptInputSubmit>
+        </div>
+      </PromptInputFooter>
+    </PromptInput>
+  )
+}
+
+function PlatformToggle({
+  value,
+  onChange,
+}: {
+  value: "web" | "mobile"
+  onChange: (platform: "web" | "mobile") => void
+}) {
+  return (
+    <div className="flex justify-center mb-6">
+      <div className="inline-flex items-center gap-1 p-1 rounded-lg bg-muted/50 border border-border/30">
+        <button
+          onClick={() => onChange("web")}
+          className={cn(
+            "flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-all duration-200",
+            value === "web"
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          <Monitor size={16} />
+          Web
+        </button>
+        <button
+          onClick={() => onChange("mobile")}
+          className={cn(
+            "flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-all duration-200",
+            value === "mobile"
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          <Smartphone size={16} />
+          Mobile
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/routes/studio.$sessionId.tsx
+++ b/apps/desktop/src/routes/studio.$sessionId.tsx
@@ -54,8 +54,13 @@ import { toast } from "sonner"
 import { bridge } from "@/lib/bridge"
 
 export const Route = createFileRoute("/studio/$sessionId")({
-  component: StudioPage,
+  component: StudioRoutePage,
 })
+
+function StudioRoutePage() {
+  const { sessionId } = useParams({ from: "/studio/$sessionId" })
+  return <StudioPageContent sessionId={sessionId} />
+}
 
 // Layout constants
 const MOBILE_WIDTH = 280
@@ -68,8 +73,13 @@ const START_Y = 40
 const MOBILE_COLUMNS = 4
 const WEB_COLUMNS = 2
 
-function StudioPage() {
-  const { sessionId } = useParams({ from: "/studio/$sessionId" })
+export function StudioPageContent({
+  sessionId,
+  projectId,
+}: {
+  sessionId: string
+  projectId?: string
+}) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [renameOpen, setRenameOpen] = useState(false)
@@ -148,7 +158,8 @@ function StudioPage() {
   const handleDeleteScreen = useCallback(async () => {
     if (!deleteTarget || !currentSession?.cwd) return
 
-    const filePath = `${currentSession.cwd}/screens/${deleteTarget.filename}`
+    const design = designs.find((item) => item.filename === deleteTarget.filename)
+    const filePath = design?.file_path ?? `${currentSession.cwd}/.designs/${deleteTarget.filename}`
     try {
       await bridge.designs.delete({ filePath })
       // Remove from positions
@@ -177,9 +188,19 @@ function StudioPage() {
   const handleForkSession = useCallback(async () => {
     const newSessionId = await forkSessionDesignsOnly()
     if (newSessionId) {
-      navigate({ to: "/studio/$sessionId", params: { sessionId: newSessionId } })
+      if (projectId ?? currentSession?.projectId) {
+        navigate({
+          to: "/project/$projectId/session/$sessionId",
+          params: {
+            projectId: projectId ?? currentSession?.projectId ?? "",
+            sessionId: newSessionId,
+          },
+        })
+      } else {
+        navigate({ to: "/studio/$sessionId", params: { sessionId: newSessionId } })
+      }
     }
-  }, [forkSessionDesignsOnly, navigate])
+  }, [forkSessionDesignsOnly, navigate, projectId, currentSession?.projectId])
 
   const handleRequestDelete = useCallback(
     (filename: string) => {
@@ -194,15 +215,24 @@ function StudioPage() {
   const handleRename = useCallback(async () => {
     if (!currentSession || !newName.trim()) return
 
-    await updateSession({
-      id: sessionId,
-      updates: { name: newName.trim() },
-    })
+    if (currentSession.projectId) {
+      await bridge.agent.renameSession({
+        sessionID: sessionId,
+        name: newName.trim(),
+        directory: currentSession.cwd,
+      })
+      queryClient.invalidateQueries({ queryKey: ["sessions", "list"] })
+    } else {
+      await updateSession({
+        id: sessionId,
+        updates: { name: newName.trim() },
+      })
 
-    await bridge.agent.renameSession({ sessionID: sessionId, name: newName.trim() })
+      await bridge.agent.renameSession({ sessionID: sessionId, name: newName.trim() })
+    }
 
     setRenameOpen(false)
-  }, [currentSession, newName, sessionId, updateSession])
+  }, [currentSession, newName, sessionId, updateSession, queryClient])
 
   // Auto-send initial prompt if stored
   useEffect(() => {
@@ -261,7 +291,7 @@ function StudioPage() {
         <PageHeader>
           <PageHeaderLeft>
             <span className="text-sm font-medium truncate max-w-[200px]">
-              {currentSession?.name ?? "Untitled"}
+              {currentSession?.name ?? "Untitled chat"}
             </span>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -288,7 +318,7 @@ function StudioPage() {
                   disabled={!currentSession?.cwd}
                 >
                   <Copy size={16} className="mr-2" />
-                  Copy session path
+                  Copy project path
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => {
@@ -300,7 +330,7 @@ function StudioPage() {
                   disabled={!currentSession?.id}
                 >
                   <Copy size={16} className="mr-2" />
-                  Copy session ID
+                  Copy chat ID
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -399,7 +429,7 @@ function StudioPage() {
         <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
           <DialogContent className="sm:max-w-[400px]">
             <DialogHeader>
-              <DialogTitle>Rename Session</DialogTitle>
+              <DialogTitle>Rename chat</DialogTitle>
             </DialogHeader>
             <form
               onSubmit={(e) => {

--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -30,6 +30,7 @@ const desktopBridgeMock: DesktopBridge = {
     setApiKey: vi.fn(),
     loginOAuthProvider: vi.fn(),
     createSession: vi.fn(),
+    listSessions: vi.fn(),
     getSession: vi.fn(),
     getMessages: vi.fn(),
     prompt: vi.fn(),
@@ -51,6 +52,16 @@ const desktopBridgeMock: DesktopBridge = {
     loadMeta: vi.fn(),
     deleteMeta: vi.fn(),
     toggleFavorite: vi.fn(),
+  },
+  projects: {
+    list: vi.fn(),
+    create: vi.fn(),
+    addExisting: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+    touch: vi.fn(),
+    getLegacyNotice: vi.fn(),
+    dismissLegacyNotice: vi.fn(),
   },
   designs: {
     loadForSession: vi.fn(),
@@ -75,7 +86,7 @@ const desktopBridgeMock: DesktopBridge = {
     onViteError: vi.fn(() => noopUnsubscribe),
   },
   fs: { stat: vi.fn(), writeFile: vi.fn() },
-  dialog: { save: vi.fn() },
+  dialog: { save: vi.fn(), openDirectory: vi.fn() },
   shell: { openExternal: vi.fn() },
   updater: {
     check: vi.fn(),

--- a/packages/desktop-bridge/src/index.ts
+++ b/packages/desktop-bridge/src/index.ts
@@ -14,11 +14,14 @@ import type {
   AgentQuestionRequest,
   AgentRuntimeInfo,
   AgentSessionInfo,
+  AgentSessionSummary,
   AgentThinkingLevel,
   AgentTreeNode,
   DesignFile,
   FileNode,
   MenuEventId,
+  Platform,
+  ProjectMeta,
   SaveDialogOptions,
   SessionMeta,
   SkillInfo,
@@ -55,6 +58,7 @@ export interface DesktopBridge {
     setApiKey(args: { providerID: string; apiKey: string }): Promise<void>
     loginOAuthProvider(args: { providerID: string }): Promise<void>
     createSession(args: { directory: string }): Promise<AgentSessionInfo>
+    listSessions(args: { directory: string }): Promise<AgentSessionSummary[]>
     getSession(args: { sessionID: string; directory: string }): Promise<AgentSessionInfo>
     getMessages(args: { sessionID: string; directory: string }): Promise<AgentMessage[]>
     prompt(args: {
@@ -66,8 +70,8 @@ export interface DesktopBridge {
       thinkingLevel?: AgentThinkingLevel
     }): Promise<void>
     abort(args: { sessionID: string }): Promise<void>
-    renameSession(args: { sessionID: string; name: string }): Promise<void>
-    deleteSession(args: { sessionID: string }): Promise<void>
+    renameSession(args: { sessionID: string; name: string; directory?: string }): Promise<void>
+    deleteSession(args: { sessionID: string; directory?: string }): Promise<void>
     listQuestions(): Promise<AgentQuestionRequest[]>
     replyQuestion(args: { requestID: string; answers: string[][] }): Promise<void>
     rejectQuestion(args: { requestID: string }): Promise<void>
@@ -97,6 +101,20 @@ export interface DesktopBridge {
     loadMeta(): Promise<SessionMeta[]>
     deleteMeta(args: { sessionId: string }): Promise<void>
     toggleFavorite(args: { sessionId: string }): Promise<boolean>
+  }
+
+  projects: {
+    list(): Promise<ProjectMeta[]>
+    create(args: { name: string; platform?: Platform }): Promise<ProjectMeta>
+    addExisting(args: { path: string; platform?: Platform }): Promise<ProjectMeta>
+    update(args: {
+      id: string
+      updates: Partial<Pick<ProjectMeta, "name" | "platform" | "pinned" | "expanded">>
+    }): Promise<ProjectMeta>
+    remove(args: { id: string }): Promise<void>
+    touch(args: { id: string }): Promise<ProjectMeta>
+    getLegacyNotice(): Promise<{ hasLegacySessions: boolean; dismissed: boolean }>
+    dismissLegacyNotice(): Promise<void>
   }
 
   designs: {
@@ -143,6 +161,7 @@ export interface DesktopBridge {
 
   dialog: {
     save(options: SaveDialogOptions): Promise<string | null>
+    openDirectory(): Promise<string | null>
   }
 
   shell: {
@@ -175,11 +194,13 @@ export type {
   AgentQuestionRequest,
   AgentRuntimeInfo,
   AgentSessionInfo,
+  AgentSessionSummary,
   AgentThinkingLevel,
   AgentTreeNode,
   DesignFile,
   FileNode,
   MenuEventId,
+  ProjectMeta,
   SaveDialogOptions,
   SessionMeta,
   SkillInfo,

--- a/packages/desktop-bridge/src/types.ts
+++ b/packages/desktop-bridge/src/types.ts
@@ -20,6 +20,28 @@ export interface SessionMeta {
   parentID?: string
   platform?: Platform
   favorite?: boolean
+  projectId?: string
+}
+
+export interface ProjectMeta {
+  id: string
+  name: string
+  path: string
+  platform: Platform
+  pinned: boolean
+  expanded: boolean
+  created_at: string
+  last_opened_at: string
+}
+
+export interface AgentSessionSummary {
+  id: string
+  cwd: string
+  name?: string
+  created_at: string
+  updated_at: string
+  message_count: number
+  first_message: string
 }
 
 export type ViolationRule =
@@ -37,6 +59,7 @@ export interface Violation {
 
 export interface DesignFile {
   filename: string
+  file_path: string
   title: string
   screen_type: string
   html: string


### PR DESCRIPTION
## Summary
- add persistent local Project records backed by the Dilag state database
- group Pi sessions by project folder and expose project/session IPC through the desktop bridge
- move generated designs to `.designs/*.html` while keeping legacy screen loading support
- update the home, sidebar, and studio routes for project-scoped chats

## Validation
- `bun run fmt:check`
- `bun run typecheck`
- `bun run test`

## Impact
Users can start from a new local project folder or add an existing folder, then manage chats under that project instead of relying on standalone session metadata.