### PR TITLE
Fix Pi prompt flow and refine chat work blocks

### DIFF
--- a/apps/desktop/electron/ipc/pi.ts
+++ b/apps/desktop/electron/ipc/pi.ts
@@ -92,6 +92,13 @@ type PiSessionTreeNode = {
 const sessions = new Map<string, RuntimeSession>()
 const pendingQuestions = new Map<string, PendingQuestion>()
 const OAUTH_PROVIDER_IDS = new Set(["openai-codex", "github-copilot"])
+const STALE_DEFAULT_MODELS = new Set(["google/gemini-1.5-flash"])
+const PREFERRED_DEFAULT_MODELS = [
+  "opencode-go/kimi-k2.6",
+  "google/gemini-2.5-flash",
+  "google/gemini-2.5-pro",
+]
+const DEBUG_PI_SMOKE = process.env.DILAG_DEBUG_PI === "1"
 
 let eventSender: EventSender | undefined
 let piModulePromise: Promise<typeof import("@earendil-works/pi-coding-agent")> | undefined
@@ -153,11 +160,13 @@ export async function getAgentProviderData(): Promise<AgentProviderData> {
     variants: getThinkingLevelVariants(model),
   }))
   const connectedProviders = [...new Set(models.map((model) => model.providerID))]
-  const first = models[0]
+  const defaultModel = chooseDefaultModel(models)
   return {
     models,
     connectedProviders,
-    defaultModel: first ? { providerID: first.providerID, modelID: first.id } : null,
+    defaultModel: defaultModel
+      ? { providerID: defaultModel.providerID, modelID: defaultModel.id }
+      : null,
   }
 }
 
@@ -177,6 +186,20 @@ function getThinkingLevelVariants(model: {
     AgentThinkingLevel,
     Record<string, unknown>
   >
+}
+
+function modelKey(model: { providerID?: string; provider?: string; id: string }): string {
+  return `${model.providerID ?? model.provider}/${model.id}`
+}
+
+function chooseDefaultModel<T extends { providerID?: string; provider?: string; id: string }>(
+  models: T[],
+): T | undefined {
+  for (const preferred of PREFERRED_DEFAULT_MODELS) {
+    const model = models.find((candidate) => modelKey(candidate) === preferred)
+    if (model) return model
+  }
+  return models.find((model) => !STALE_DEFAULT_MODELS.has(modelKey(model))) ?? models[0]
 }
 
 export async function listAgentProviders(): Promise<AgentProvider[]> {
@@ -280,8 +303,52 @@ export async function promptAgentSession(args: {
     args.thinkingLevel,
   )
   emitSessionStatus(runtime.id, "running")
-  void runtime.session.prompt(args.text, { images: args.images }).catch((error: unknown) => {
-    emitSessionError(runtime.id, error)
+  debugPiSmoke("prompt.start", {
+    sessionID: runtime.id,
+    cwd: runtime.cwd,
+    model: runtime.session.model
+      ? `${runtime.session.model.provider}/${runtime.session.model.id}`
+      : null,
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    let accepted = false
+    let settled = false
+
+    const resolveOnce = () => {
+      if (settled) return
+      settled = true
+      resolve()
+    }
+
+    const rejectOnce = (error: unknown) => {
+      if (settled) return
+      settled = true
+      reject(error)
+    }
+
+    void runtime.session
+      .prompt(args.text, {
+        images: args.images,
+        preflightResult: (success) => {
+          debugPiSmoke("prompt.preflight", { sessionID: runtime.id, success })
+          if (!success) return
+          accepted = true
+          resolveOnce()
+        },
+      })
+      .then(() => {
+        debugPiSmoke("prompt.resolved", { sessionID: runtime.id, accepted })
+        if (!accepted) resolveOnce()
+      })
+      .catch((error: unknown) => {
+        debugPiSmoke("prompt.rejected", {
+          sessionID: runtime.id,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        emitSessionError(runtime.id, error)
+        rejectOnce(error)
+      })
   })
 }
 
@@ -456,7 +523,7 @@ async function createPiSession(
   const registry = await createModelRegistry()
   const model = requestedModel
     ? registry.find(requestedModel.providerID, requestedModel.modelID)
-    : registry.getAvailable()[0]
+    : chooseDefaultModel(registry.getAvailable())
   const questionTool = await createQuestionTool()
   const settingsManager = pi.SettingsManager.create(cwd, getPiAgentDir())
   const resourceLoader = new pi.DefaultResourceLoader({
@@ -755,6 +822,8 @@ function messageHasToolCall(message: PiMessage, toolCallId: string): boolean {
 }
 
 function handlePiSessionEvent(runtime: RuntimeSession, event: AgentSessionEvent) {
+  debugPiSessionEvent(runtime, event)
+
   if (
     event.type === "message_start" ||
     event.type === "message_update" ||
@@ -1226,6 +1295,24 @@ function countUnifiedDiffLines(diff: string | undefined): { additions: number; d
     if (line.startsWith("-")) deletions++
   }
   return { additions, deletions }
+}
+
+function debugPiSessionEvent(runtime: RuntimeSession, event: AgentSessionEvent) {
+  if (!DEBUG_PI_SMOKE) return
+  const message = "message" in event ? (event.message as PiMessage | undefined) : undefined
+  debugPiSmoke("event", {
+    sessionID: runtime.id,
+    cwd: runtime.cwd,
+    type: event.type,
+    role: message?.role,
+    toolName: "toolName" in event ? event.toolName : message?.toolName,
+    stopReason: message?.stopReason,
+    errorMessage: message?.errorMessage,
+  })
+}
+
+function debugPiSmoke(label: string, data: Record<string, unknown>) {
+  if (DEBUG_PI_SMOKE) console.log(`[DEBUG-pi-smoke] ${label}`, data)
 }
 
 function emitAgentEvent(event: unknown) {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,12 +18,12 @@
     "smoke:electron": "bun run build && bun scripts/smoke-electron.mjs",
     "preview": "vite preview",
     "test": "vitest",
+    "test:prompt-flow": "vitest run src/hooks/use-sessions.test.ts -t \"project chat and sends the first prompt\"",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "release": "bumpp",
     "sync-version": "bun scripts/sync-version.ts",
-    "sync-version-from-pkg": "bun scripts/sync-version-from-pkg.ts",
-    "test:prompt-flow": "vitest run src/hooks/use-sessions.test.ts -t \"project chat and sends the first prompt\""
+    "sync-version-from-pkg": "bun scripts/sync-version-from-pkg.ts"
   },
   "build": {
     "appId": "com.rohi.dilag",
@@ -102,6 +102,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "dayjs": "^1.11.19",
+    "diff": "^8.0.2",
     "embla-carousel-react": "^8.6.0",
     "howler": "^2.2.4",
     "html2canvas-pro": "^1.6.4",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,7 +22,8 @@
     "test:coverage": "vitest run --coverage",
     "release": "bumpp",
     "sync-version": "bun scripts/sync-version.ts",
-    "sync-version-from-pkg": "bun scripts/sync-version-from-pkg.ts"
+    "sync-version-from-pkg": "bun scripts/sync-version-from-pkg.ts",
+    "test:prompt-flow": "vitest run src/hooks/use-sessions.test.ts -t \"project chat and sends the first prompt\""
   },
   "build": {
     "appId": "com.rohi.dilag",

--- a/apps/desktop/scripts/dev-electron.mjs
+++ b/apps/desktop/scripts/dev-electron.mjs
@@ -84,8 +84,14 @@ function spawnElectron() {
     electronProc.removeAllListeners("exit")
     electronProc.kill()
   }
+  const electronArgs = [path.join(DIST_ELECTRON, "main.cjs")]
+  const remoteDebuggingPort = process.env.ELECTRON_REMOTE_DEBUGGING_PORT
+  if (remoteDebuggingPort) {
+    electronArgs.push(`--remote-debugging-port=${remoteDebuggingPort}`)
+  }
+
   electronProc = track(
-    spawn(electronPath, [path.join(DIST_ELECTRON, "main.cjs")], {
+    spawn(electronPath, electronArgs, {
       cwd: APP_ROOT,
       env: { ...process.env, VITE_DEV_SERVER_URL: viteUrl },
       stdio: ["ignore", "pipe", "pipe"],

--- a/apps/desktop/src/components/ai-elements/reasoning.tsx
+++ b/apps/desktop/src/components/ai-elements/reasoning.tsx
@@ -3,7 +3,7 @@
 import { useControllableState } from "@radix-ui/react-use-controllable-state"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@dilag/ui/collapsible"
 import { cn } from "@/lib/utils"
-import { Lightbulb, AltArrowDown } from "@solar-icons/react"
+import { Lightbulb } from "lucide-react"
 import type { ComponentProps, ReactNode } from "react"
 import { createContext, memo, useContext, useEffect, useState } from "react"
 import { Streamdown } from "streamdown"
@@ -126,24 +126,26 @@ export const ReasoningTrigger = memo(
     getThinkingMessage = defaultGetThinkingMessage,
     ...props
   }: ReasoningTriggerProps) => {
-    const { isStreaming, isOpen, duration } = useReasoning()
+    const { isStreaming, duration } = useReasoning()
 
     return (
       <CollapsibleTrigger
         className={cn(
-          "flex w-full items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground",
+          "group grid h-8 w-full grid-cols-[16px_minmax(0,1fr)] items-center gap-2.5 rounded-md px-2 py-1.5 text-left",
+          "text-sm text-muted-foreground select-none cursor-default transition-colors",
+          "hover:bg-muted/30 hover:text-foreground data-[state=open]:bg-muted/20 data-[state=open]:text-foreground",
           className,
         )}
         {...props}
       >
         {children ?? (
           <>
-            <Lightbulb size={16} />
-            {getThinkingMessage(isStreaming, duration)}
-            <AltArrowDown
-              size={16}
-              className={cn("transition-transform", isOpen ? "rotate-180" : "rotate-0")}
-            />
+            <span className="flex size-4 shrink-0 items-center justify-center text-muted-foreground/80">
+              <Lightbulb className="size-[15px] stroke-[1.75]" />
+            </span>
+            <span className="min-w-0 flex-1 truncate text-left">
+              {getThinkingMessage(isStreaming, duration)}
+            </span>
           </>
         )}
       </CollapsibleTrigger>

--- a/apps/desktop/src/components/blocks/chat/chat-view.tsx
+++ b/apps/desktop/src/components/blocks/chat/chat-view.tsx
@@ -1361,8 +1361,9 @@ export function ChatView() {
                 while (turnStart > 0 && messages[turnStart - 1].role === "assistant") turnStart--
                 const turnAssistantMessages = messages
                   .slice(turnStart, index + 1)
-                  .filter((item): item is SessionMessage & { role: "assistant" } =>
-                    item.role === "assistant",
+                  .filter(
+                    (item): item is SessionMessage & { role: "assistant" } =>
+                      item.role === "assistant",
                   )
 
                 return message.role === "user" ? (

--- a/apps/desktop/src/components/blocks/chat/chat-view.tsx
+++ b/apps/desktop/src/components/blocks/chat/chat-view.tsx
@@ -22,6 +22,7 @@ import {
   UndoLeft,
   ClockCircle,
   Copy,
+  AltArrowRight,
 } from "@solar-icons/react"
 import { usePendingMessage } from "@/hooks/use-chat-interface"
 import { DilagIcon } from "@/components/blocks/branding/dilag-icon"
@@ -31,9 +32,6 @@ import {
   useSessionError,
   useSessionRevert,
   useSessionStore,
-  usePendingQuestions,
-  useRunningQuestionTools,
-  useRunningPermissionTools,
   type SessionStatus,
   type Message as SessionMessage,
 } from "@/context/session-store"
@@ -54,7 +52,6 @@ import {
   MessageAction,
   MessageResponse,
 } from "@/components/ai-elements/message"
-import { useElapsedTime } from "@/hooks/use-elapsed-time"
 import {
   PromptInput,
   PromptInputTextarea,
@@ -293,42 +290,12 @@ export function isAssistantMessageStreaming(
   )
 }
 
-const BUSY_FALLBACKS = [
-  "Thinking",
-  "Designing",
-  "Sketching",
-  "Refining",
-  "Polishing",
-  "Exploring",
-  "Planning",
-  "Cooking",
-] as const
-
-function useBusyFallbackOnce(active: boolean): string {
-  const [label, setLabel] = useState<string>(BUSY_FALLBACKS[0])
-  const prevActiveRef = useRef(false)
-  const lastLabelRef = useRef<string>(label)
-
-  useEffect(() => {
-    lastLabelRef.current = label
-  }, [label])
-
-  useEffect(() => {
-    const wasActive = prevActiveRef.current
-    prevActiveRef.current = active
-
-    // Pick once when we *enter* active state.
-    if (active && !wasActive) {
-      let next = lastLabelRef.current
-      // Avoid repeating the same label when possible
-      for (let attempts = 0; attempts < 5 && next === lastLabelRef.current; attempts++) {
-        next = BUSY_FALLBACKS[Math.floor(Math.random() * BUSY_FALLBACKS.length)]
-      }
-      setLabel(next)
-    }
-  }, [active])
-
-  return label
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000))
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes > 0) return `${minutes}m ${seconds}s`
+  return `${seconds}s`
 }
 
 function ThinkingIndicator() {
@@ -363,48 +330,6 @@ function InlineErrorCard({ error }: { error: { name: string; message: string } }
       <div className="flex flex-col gap-0.5 min-w-0">
         <span className="text-sm font-medium text-destructive">{formattedName || "Error"}</span>
         <span className="text-sm text-destructive/80 break-words">{error.message}</span>
-      </div>
-    </div>
-  )
-}
-
-// Component to show total session duration (from first message to current message completion)
-function MessageDuration({
-  message,
-  sessionStartTime,
-  activityLabel,
-}: {
-  message: SessionMessage
-  sessionStartTime: number
-  activityLabel?: string
-}) {
-  const startTime = sessionStartTime
-  // Only freeze the timer when the message is actually marked completed.
-  // Using Date.now() here causes the display to "stick" and then jump when rerendered.
-  const endTime = message.time.completed
-  const elapsed = useElapsedTime(startTime, endTime)
-  const showActivity = endTime === undefined && !!activityLabel
-  const isActive = endTime === undefined
-
-  return (
-    <div className="flex items-center gap-2.5 pt-3 pb-1">
-      <DilagIcon
-        animated={isActive}
-        className={cn(
-          "size-3.5 transition-colors duration-300",
-          isActive ? "text-primary" : "text-muted-foreground",
-        )}
-      />
-      <div className="flex items-baseline gap-1.5">
-        {showActivity && <span className="text-[13px] text-muted-foreground">{activityLabel}</span>}
-        <span
-          className={cn(
-            "font-mono text-[13px] tabular-nums tracking-tight transition-colors duration-300",
-            isActive ? "text-foreground" : "text-muted-foreground",
-          )}
-        >
-          {elapsed}
-        </span>
       </div>
     </div>
   )
@@ -466,17 +391,28 @@ function SkillInvocationBlock({ skill }: { skill: ParsedSkillBlock }) {
       <Collapsible>
         <CollapsibleTrigger
           className={cn(
-            "group flex h-8 w-fit max-w-full items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-1.5",
-            "text-sm text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground",
+            "group flex h-8 w-full items-center justify-between gap-2 rounded-md px-2 py-1.5",
+            "text-sm select-none cursor-default text-muted-foreground transition-colors",
+            "hover:bg-muted/30 hover:text-foreground data-[state=open]:bg-muted/20 data-[state=open]:text-foreground",
           )}
         >
-          <MagicStick size={16} className="shrink-0 text-primary/70" />
-          <span className="font-medium text-foreground">Skill</span>
-          <span className="truncate">{skill.name}</span>
+          <div className="flex min-w-0 flex-1 items-center overflow-hidden text-left">
+            <span className="truncate font-medium text-foreground">Used {skill.name}</span>
+          </div>
+          <AltArrowRight
+            size={16}
+            className={cn(
+              "shrink-0 text-muted-foreground opacity-0 transition-all duration-150",
+              "group-hover:opacity-100 group-data-[state=open]:opacity-100 group-data-[state=open]:rotate-90",
+            )}
+          />
         </CollapsibleTrigger>
-        <CollapsibleContent className="mt-2 max-h-80 overflow-y-auto rounded-md border border-border/40 bg-muted/20 p-3 text-sm">
-          <div className="prose prose-sm prose-invert max-w-none">
-            <MessageResponse>{`**${skill.name}**\n\n${skill.content}`}</MessageResponse>
+        <CollapsibleContent className="mt-1 overflow-hidden rounded-lg bg-[#2a2a2a] text-[#e2e2e2] shadow-sm">
+          <div className="max-h-72 overflow-y-auto p-3">
+            <div className="mb-3 text-xs font-medium text-[#a8a8a8]">Skill</div>
+            <div className="prose prose-sm prose-invert max-w-none text-sm [&_pre]:!bg-transparent [&_code]:!bg-transparent [&_pre]:!m-0 [&_pre]:!p-0 [&_pre]:!text-[#e2e2e2] [&_code]:!text-[#e2e2e2] [&_*]:!border-neutral-700/70">
+              <MessageResponse>{`**${skill.name}**\n\n${skill.content}`}</MessageResponse>
+            </div>
           </div>
         </CollapsibleContent>
       </Collapsible>
@@ -589,14 +525,72 @@ function UserMessage({
     </>
   )
 }
+function splitAssistantWorkParts(parts: MessagePartType[]) {
+  let finalTextStart = parts.length
+  while (finalTextStart > 0 && parts[finalTextStart - 1]?.type === "text") {
+    finalTextStart--
+  }
+  return {
+    workParts: parts.slice(0, finalTextStart),
+    finalParts: parts.slice(finalTextStart),
+  }
+}
+
+function AssistantWorkGroup({
+  parts,
+  isStreaming,
+  startedAt,
+  completedAt,
+}: {
+  parts: MessagePartType[]
+  isStreaming: boolean
+  startedAt: number
+  completedAt?: number
+}) {
+  if (parts.length === 0) return null
+
+  const completed = completedAt ?? Date.now()
+  const elapsed = formatDuration(completed - startedAt)
+  const commandCount = parts.filter((part) => part.type === "tool").length
+
+  return (
+    <Collapsible>
+      <CollapsibleTrigger
+        className={cn(
+          "group flex h-8 w-full items-center justify-start gap-2.5 rounded-md px-0 py-1.5",
+          "text-sm text-muted-foreground transition-colors hover:text-foreground",
+        )}
+      >
+        <span>
+          Worked for {elapsed}
+          {commandCount > 0 && `, ${commandCount} command${commandCount === 1 ? "" : "s"}`}
+        </span>
+        <AltArrowRight
+          size={14}
+          className="shrink-0 text-muted-foreground transition-transform duration-150 group-data-[state=open]:rotate-90"
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="space-y-2 border-b border-border/40 pb-3">
+        {parts.map((part, partIndex) => (
+          <div
+            key={part.id}
+            className="animate-stream-in"
+            style={{ animationDelay: `${partIndex * 35}ms` }}
+          >
+            <MessagePart part={part} isStreaming={isStreaming} />
+          </div>
+        ))}
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
 // Component that renders an assistant message with parts from the store
 function AssistantMessage({
   message,
   index,
   isLast,
-  showTimer,
-  sessionStartTime,
-  activityLabel,
+  turnAssistantMessages,
   onFork,
   onCopyText,
   onOpenTimeline,
@@ -604,20 +598,29 @@ function AssistantMessage({
   message: SessionMessage
   index: number
   isLast: boolean
-  showTimer: boolean
-  sessionStartTime: number
-  activityLabel?: string
+  turnAssistantMessages: SessionMessage[]
   onFork: (messageId: string) => void
   onCopyText: (messageId: string) => void
   onOpenTimeline: () => void
 }) {
   const parts = useMessageParts(message.id)
+  const partsByMessageId = useSessionStore((state) => state.parts)
+  const turnParts = useMemo(
+    () => turnAssistantMessages.flatMap((turnMessage) => partsByMessageId[turnMessage.id] ?? []),
+    [partsByMessageId, turnAssistantMessages],
+  )
   const sessionError = useSessionError(message.sessionID)
   const sessionStatus = useSessionStore(
     (state) => state.sessionStatus[message.sessionID] ?? "unknown",
   )
   const isStreaming = isAssistantMessageStreaming(message, sessionStatus)
   const renderableParts = getRenderableAssistantParts(parts, isStreaming)
+  const turnRenderableParts = getRenderableAssistantParts(turnParts, isStreaming)
+  const { finalParts } = splitAssistantWorkParts(renderableParts)
+  const finalPartIds = new Set(finalParts.map((part) => part.id))
+  const workParts = turnRenderableParts.filter((part) => !finalPartIds.has(part.id))
+  const workStartedAt = turnAssistantMessages[0]?.time.created ?? message.time.created
+  const workCompletedAt = message.time.completed
 
   if (!isStreaming && renderableParts.length === 0 && !sessionError) {
     return null
@@ -630,7 +633,14 @@ function AssistantMessage({
       style={{ animationDelay: `${Math.min(index * 30, 200)}ms` }}
     >
       <MessageContent className="space-y-2 w-full">
-        {renderableParts.map((part, partIndex) => (
+        <AssistantWorkGroup
+          parts={workParts}
+          isStreaming={isStreaming}
+          startedAt={workStartedAt}
+          completedAt={workCompletedAt}
+        />
+
+        {finalParts.map((part, partIndex) => (
           <div
             key={part.id}
             className="animate-stream-in"
@@ -658,14 +668,6 @@ function AssistantMessage({
             <ClockCircle size={14} />
           </MessageAction>
         </MessageActions>
-      )}
-      {/* Duration timer - only show on last assistant message before next user message */}
-      {showTimer && (
-        <MessageDuration
-          message={message}
-          sessionStartTime={sessionStartTime}
-          activityLabel={activityLabel}
-        />
       )}
     </Message>
   )
@@ -1243,7 +1245,6 @@ export function ChatView() {
     forkSession,
     revertToMessage,
     unrevertSession,
-    sessionStatus,
   } = useSessions()
 
   const navigate = useNavigate()
@@ -1315,49 +1316,6 @@ export function ChatView() {
     return firstAssistant.isStreaming && firstAssistant.time.completed === undefined
   }, [messages])
 
-  // Activity cues (derived from available session events/state)
-  const pendingQuestions = usePendingQuestions(currentSessionId)
-  const runningQuestionTools = useRunningQuestionTools(currentSessionId)
-  const runningPermissionTools = useRunningPermissionTools(currentSessionId)
-  const busyFallbackOnce = useBusyFallbackOnce(isLoading)
-
-  const activityLabel = useMemo(
-    () =>
-      getChatActivityLabel({
-        isLoading,
-        pendingQuestionCount: pendingQuestions.length,
-        runningQuestionToolCount: runningQuestionTools.length,
-        runningTools: runningPermissionTools,
-        sessionStatus,
-        fallback: busyFallbackOnce,
-      }),
-    [
-      isLoading,
-      pendingQuestions.length,
-      runningQuestionTools.length,
-      runningPermissionTools,
-      sessionStatus,
-      busyFallbackOnce,
-    ],
-  )
-
-  // Memoize turn start times (each user message starts a new turn)
-  // Returns the most recent user message timestamp before a given index
-  const getTurnStartTime = useMemo(() => {
-    // Build a map of turn start times for each message index
-    const turnStarts: number[] = []
-    let currentTurnStart = messages[0]?.time.created ?? 0
-
-    for (let i = 0; i < messages.length; i++) {
-      if (messages[i].role === "user") {
-        currentTurnStart = messages[i].time.created
-      }
-      turnStarts[i] = currentTurnStart
-    }
-
-    return (index: number) => turnStarts[index] ?? 0
-  }, [messages])
-
   if (!isServerReady) {
     return <LoadingState />
   }
@@ -1395,10 +1353,17 @@ export function ChatView() {
                   message.role === "assistant" &&
                   !messages.slice(index + 1).some((m) => m.role === "assistant")
 
-                // Show timer on assistant messages that are followed by a user message or are at the end
                 const nextMessage = messages[index + 1]
-                const showTimer =
-                  message.role === "assistant" && (!nextMessage || nextMessage.role === "user")
+                const isLastAssistantInTurn = !nextMessage || nextMessage.role === "user"
+                if (message.role === "assistant" && !isLastAssistantInTurn) return null
+
+                let turnStart = index
+                while (turnStart > 0 && messages[turnStart - 1].role === "assistant") turnStart--
+                const turnAssistantMessages = messages
+                  .slice(turnStart, index + 1)
+                  .filter((item): item is SessionMessage & { role: "assistant" } =>
+                    item.role === "assistant",
+                  )
 
                 return message.role === "user" ? (
                   <UserMessage
@@ -1417,13 +1382,7 @@ export function ChatView() {
                     message={message}
                     index={index}
                     isLast={isLastAssistant}
-                    showTimer={showTimer}
-                    sessionStartTime={getTurnStartTime(index)}
-                    activityLabel={
-                      isLastAssistant && isLoading && message.time.completed === undefined
-                        ? activityLabel
-                        : undefined
-                    }
+                    turnAssistantMessages={turnAssistantMessages}
                     onFork={handleFork}
                     onCopyText={handleCopyText}
                     onOpenTimeline={handleOpenTimeline}

--- a/apps/desktop/src/components/blocks/chat/message-part.tsx
+++ b/apps/desktop/src/components/blocks/chat/message-part.tsx
@@ -31,7 +31,7 @@ function MessagePartContent({ part, isStreaming = false }: MessagePartProps) {
     case "reasoning":
       if (!part.text?.trim()) return null
       return (
-        <Reasoning isStreaming={isStreaming} className="mb-0">
+        <Reasoning isStreaming={isStreaming} defaultOpen={false} className="mb-0">
           <ReasoningTrigger />
           <ReasoningContent>{part.text}</ReasoningContent>
         </Reasoning>

--- a/apps/desktop/src/components/blocks/chat/tool-part.test.tsx
+++ b/apps/desktop/src/components/blocks/chat/tool-part.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { describe, expect, it } from "vitest"
 import { ToolPart } from "./tool-part"
 
 describe("ToolPart", () => {
-  it("shows completed read output by default", async () => {
+  it("shows completed read output after expanding", async () => {
     render(
       <ToolPart
         tool="read"
@@ -15,7 +16,12 @@ describe("ToolPart", () => {
       />,
     )
 
-    expect(screen.getByText("Read")).toBeInTheDocument()
+    const trigger = screen.getByRole("button", { name: /Read.*wellness\.html/ })
+    expect(trigger).toBeInTheDocument()
+    expect(screen.queryByText(/Wellness content/)).not.toBeInTheDocument()
+
+    await userEvent.click(trigger)
+
     expect(await screen.findByText(/Wellness content/)).toBeInTheDocument()
   })
 })

--- a/apps/desktop/src/components/blocks/chat/tool-part.tsx
+++ b/apps/desktop/src/components/blocks/chat/tool-part.tsx
@@ -46,7 +46,11 @@ export function ToolPart({ tool, state }: ToolPartProps) {
   const statusLabel =
     state.status === "completed" ? "Success" : state.status === "error" ? "Failed" : "Running"
   const StatusIcon =
-    state.status === "completed" ? CheckCircle : state.status === "error" ? DangerTriangle : ClockCircle
+    state.status === "completed"
+      ? CheckCircle
+      : state.status === "error"
+        ? DangerTriangle
+        : ClockCircle
 
   return (
     <Collapsible defaultOpen={defaultOpen}>

--- a/apps/desktop/src/components/blocks/chat/tool-part.tsx
+++ b/apps/desktop/src/components/blocks/chat/tool-part.tsx
@@ -1,18 +1,25 @@
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@dilag/ui/collapsible"
-import { AltArrowRight } from "@solar-icons/react"
+import { AltArrowRight, CheckCircle, DangerTriangle, ClockCircle } from "@solar-icons/react"
 import { getToolConfig, isStructuredSubtitle, type ToolRenderProps } from "@/lib/tool-registry"
 import type { ToolState } from "@/context/session-store"
 import { cn } from "@/lib/utils"
 import { Shimmer } from "@/components/ai-elements/shimmer"
 import { useElapsedTime } from "@/hooks/use-elapsed-time"
+import type { ReactNode } from "react"
 
 interface ToolPartProps {
   tool: string
   state: ToolState
 }
 
-// Tools that should be expanded by default
-const DEFAULT_OPEN_TOOLS = ["read", "todowrite", "question"]
+// Tools are collapsed by default; the turn-level work group owns first-level disclosure.
+const DEFAULT_OPEN_TOOLS: string[] = []
+
+function renderSubtitleText(subtitle: ReactNode | { text: ReactNode }) {
+  const value = isStructuredSubtitle(subtitle) ? subtitle.text : subtitle
+  if (typeof value === "string" || typeof value === "number") return String(value)
+  return "Working"
+}
 
 export function ToolPart({ tool, state }: ToolPartProps) {
   const config = getToolConfig(tool)
@@ -31,42 +38,57 @@ export function ToolPart({ tool, state }: ToolPartProps) {
   }
 
   const title = config.title(props)
+  const expandedTitle = config.expandedTitle?.(props) ?? title
   const subtitle = config.subtitle?.(props)
   const content = config.content?.(props)
   const hasContent = !!content || state.status === "error"
+
+  const statusLabel =
+    state.status === "completed" ? "Success" : state.status === "error" ? "Failed" : "Running"
+  const StatusIcon =
+    state.status === "completed" ? CheckCircle : state.status === "error" ? DangerTriangle : ClockCircle
 
   return (
     <Collapsible defaultOpen={defaultOpen}>
       <CollapsibleTrigger
         className={cn(
           "group flex w-full items-center justify-between gap-2",
-          "h-8 px-3 py-1.5 rounded-md",
-          "bg-muted/30 border border-border/50",
+          "h-8 px-2 py-1.5 rounded-md",
           "text-sm select-none cursor-default",
-          "hover:bg-muted/50 transition-colors",
+          "text-muted-foreground hover:bg-muted/30 hover:text-foreground transition-colors",
+          "data-[state=open]:bg-muted/20 data-[state=open]:text-foreground",
         )}
       >
-        <div className="flex items-center gap-3 flex-1 min-w-0">
-          <Icon className="size-4 shrink-0 text-muted-foreground" />
-          <div className="flex items-center gap-2 flex-1 min-w-0 overflow-hidden">
+        <div className="grid min-w-0 flex-1 grid-cols-[16px_minmax(0,1fr)_auto] items-center gap-2.5">
+          <span className="flex size-4 shrink-0 items-center justify-center text-muted-foreground/80">
+            <Icon className="size-[15px] stroke-[1.75]" />
+          </span>
+          <div className="flex min-w-0 items-center gap-2 overflow-hidden text-left">
             {state.status === "pending" ? (
               <Shimmer className="font-medium whitespace-nowrap" duration={1.5}>
-                {title}
+                {subtitle ? renderSubtitleText(subtitle) : title}
               </Shimmer>
             ) : (
-              <span className="font-medium text-foreground whitespace-nowrap">{title}</span>
-            )}
-            {subtitle && (
-              <span className="text-muted-foreground flex items-center gap-1.5 min-w-0">
-                {isStructuredSubtitle(subtitle) ? (
-                  <>
-                    <span className="truncate">{subtitle.text}</span>
-                    {subtitle.suffix && <span className="shrink-0">{subtitle.suffix}</span>}
-                  </>
-                ) : (
-                  <span className="truncate">{subtitle}</span>
-                )}
-              </span>
+              <>
+                <span className="hidden truncate font-medium text-foreground group-data-[state=open]:inline">
+                  {expandedTitle}
+                </span>
+                <span className="flex min-w-0 items-center gap-1.5 group-data-[state=open]:hidden">
+                  <span className="font-medium text-foreground whitespace-nowrap">{title}</span>
+                  {subtitle ? (
+                    <span className="flex min-w-0 items-center gap-1.5 text-muted-foreground">
+                      {isStructuredSubtitle(subtitle) ? (
+                        <>
+                          <span className="truncate">{subtitle.text}</span>
+                          {subtitle.suffix && <span className="shrink-0">{subtitle.suffix}</span>}
+                        </>
+                      ) : (
+                        <span className="truncate">{subtitle}</span>
+                      )}
+                    </span>
+                  ) : null}
+                </span>
+              </>
             )}
           </div>
           {state.status === "running" && (
@@ -77,19 +99,35 @@ export function ToolPart({ tool, state }: ToolPartProps) {
           <AltArrowRight
             size={16}
             className={cn(
-              "shrink-0 text-muted-foreground transition-transform duration-150",
-              "group-data-[state=open]:rotate-90",
+              "shrink-0 text-muted-foreground opacity-0 transition-all duration-150",
+              "group-hover:opacity-100 group-data-[state=open]:opacity-100 group-data-[state=open]:rotate-90",
             )}
           />
         )}
       </CollapsibleTrigger>
 
       {hasContent && (
-        <CollapsibleContent className="px-3 py-2 max-h-60 overflow-y-auto border-t border-border/30 mt-px rounded-b-md bg-muted/20">
-          {content}
-          {state.status === "error" && state.error && (
-            <p className="text-xs text-destructive mt-2">{state.error}</p>
-          )}
+        <CollapsibleContent className="mt-1 overflow-hidden rounded-lg bg-[#2a2a2a] text-[#e2e2e2] shadow-sm">
+          <div className="max-h-72 overflow-y-auto p-3">
+            <div className="[&_pre]:!bg-transparent [&_code]:!bg-transparent [&_pre]:!m-0 [&_pre]:!p-0 [&_pre]:!text-[#e2e2e2] [&_code]:!text-[#e2e2e2] [&_*]:!border-neutral-700/70">
+              <div className="mb-3 flex items-baseline gap-2 text-xs">
+                <span className="font-medium text-[#a8a8a8]">{title}</span>
+                {subtitle && (
+                  <span className="min-w-0 truncate text-[#e2e2e2]">
+                    {renderSubtitleText(subtitle)}
+                  </span>
+                )}
+              </div>
+              {content}
+            </div>
+            {state.status === "error" && state.error && (
+              <p className="mt-3 text-xs text-red-400">{state.error}</p>
+            )}
+          </div>
+          <div className="flex items-center justify-end gap-1.5 px-3 pb-3 text-xs text-[#9b9b9b]">
+            <StatusIcon size={13} className={state.status === "error" ? "text-red-400" : ""} />
+            <span>{statusLabel}</span>
+          </div>
         </CollapsibleContent>
       )}
     </Collapsible>

--- a/apps/desktop/src/hooks/use-session-data.ts
+++ b/apps/desktop/src/hooks/use-session-data.ts
@@ -13,6 +13,13 @@ export const sessionKeys = {
   detail: (id: string) => [...sessionKeys.details(), id] as const,
 }
 
+function displayNameFromAgentSession(name: string | undefined, firstMessage: string | undefined) {
+  const source = name || firstMessage || "New chat"
+  const skillMatch = source.match(/<\/skill>\s*([\s\S]*)$/)
+  const cleaned = (skillMatch?.[1] || source).trim()
+  return cleaned || "New chat"
+}
+
 // Desktop bridge calls for local session management.
 async function loadSessionsMetadata(): Promise<SessionMeta[]> {
   const projects = await bridge.projects.list()
@@ -20,7 +27,7 @@ async function loadSessionsMetadata(): Promise<SessionMeta[]> {
     projects.map(async (project) => {
       const sessions = await bridge.agent.listSessions({ directory: project.path }).catch(() => [])
       return sessions.map((session): SessionMeta => {
-        const name = session.name || session.first_message || "New chat"
+        const name = displayNameFromAgentSession(session.name, session.first_message)
         return {
           id: session.id,
           name,

--- a/apps/desktop/src/hooks/use-sessions.test.ts
+++ b/apps/desktop/src/hooks/use-sessions.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, vi, type Mock } from "vitest"
 import { renderHook, act, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { createElement, type ReactNode } from "react"
+import type { ProjectMeta } from "@dilag/desktop-bridge"
+import type { SessionMeta } from "@/context/session-store"
 
 vi.mock("@/context/global-events", () => ({
   useGlobalEvents: vi.fn(() => ({
@@ -42,10 +44,11 @@ vi.mock("@/hooks/use-agents", () => ({
   },
 }))
 
-const mockSessions = [
+const baseMockSessions: SessionMeta[] = [
   { id: "session-1", name: "Test Session", created_at: "2024-01-01", cwd: "/mock/cwd/1" },
   { id: "session-2", name: "Another Session", created_at: "2024-01-02", cwd: "/mock/cwd/2" },
 ]
+const mockSessions = baseMockSessions.map((session) => ({ ...session }))
 
 import { useSessions } from "./use-sessions"
 import { useSessionStore } from "@/context/session-store"
@@ -53,6 +56,7 @@ import { useModelStore } from "@/hooks/use-models"
 import { useCurrentSession } from "@/hooks/use-session-data"
 
 const mockPrompt = vi.mocked(window.desktopBridge!.agent.prompt)
+const mockCreateAgentSession = vi.mocked(window.desktopBridge!.agent.createSession)
 const mockAbort = vi.mocked(window.desktopBridge!.agent.abort)
 const mockNavigateTree = vi.mocked(window.desktopBridge!.agent.navigateTree)
 const mockGetSession = vi.mocked(window.desktopBridge!.agent.getSession)
@@ -70,7 +74,17 @@ function createWrapper() {
 describe("use-sessions", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockSessions.splice(
+      0,
+      mockSessions.length,
+      ...baseMockSessions.map((session) => ({ ...session })),
+    )
     mockPrompt.mockResolvedValue(undefined)
+    mockCreateAgentSession.mockResolvedValue({
+      id: "session-new",
+      cwd: "/mock/cwd/new",
+      title: "New chat",
+    })
     mockAbort.mockResolvedValue(undefined)
     mockNavigateTree.mockResolvedValue({ cancelled: false })
     mockGetSession.mockResolvedValue({
@@ -97,6 +111,60 @@ describe("use-sessions", () => {
   })
 
   describe("sendMessage", () => {
+    it("creates a project chat and sends the first prompt in the project cwd", async () => {
+      const project: ProjectMeta = {
+        id: "project-1",
+        name: "Checkout app",
+        path: "/mock/projects/checkout-app",
+        platform: "mobile",
+        pinned: false,
+        expanded: true,
+        created_at: "2026-05-15T00:00:00.000Z",
+        last_opened_at: "2026-05-15T00:00:00.000Z",
+      }
+
+      mockCreateAgentSession.mockImplementationOnce(async ({ directory }) => {
+        mockSessions.push({
+          id: "project-session-1",
+          name: "New chat",
+          created_at: "2026-05-15T00:00:00.000Z",
+          updated_at: "2026-05-15T00:00:00.000Z",
+          cwd: directory,
+          platform: project.platform,
+          projectId: project.id,
+          favorite: project.pinned,
+        })
+        return { id: "project-session-1", cwd: directory, title: "New chat" }
+      })
+
+      const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
+
+      await act(async () => {
+        await expect(result.current.createSessionInProject(project)).resolves.toBe(
+          "project-session-1",
+        )
+      })
+
+      await waitFor(() => {
+        expect(result.current.currentSession?.cwd).toBe(project.path)
+      })
+
+      await act(async () => {
+        await result.current.sendMessage("Build a checkout flow")
+      })
+
+      expect(mockCreateAgentSession).toHaveBeenCalledWith({ directory: project.path })
+      expect(mockPrompt).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionID: "project-session-1",
+          directory: project.path,
+          text: "/skill:dilag-mobile-design Build a checkout flow",
+          images: [],
+          model: null,
+        }),
+      )
+    })
+
     it("sends prompts through the Pi bridge with the first-run skill hint", async () => {
       const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
 
@@ -188,7 +256,7 @@ describe("use-sessions", () => {
       const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
 
       await act(async () => {
-        await result.current.sendMessage("Hello")
+        await expect(result.current.sendMessage("Hello")).rejects.toThrow("API Error")
       })
 
       await waitFor(() => {

--- a/apps/desktop/src/hooks/use-sessions.ts
+++ b/apps/desktop/src/hooks/use-sessions.ts
@@ -684,28 +684,21 @@ export function useSessions() {
           model: selectedModel,
           thinkingLevel: selectedThinkingLevel,
         })
-        bridge.agent
-          .prompt({
-            sessionID: currentSessionId,
-            directory,
-            text: promptText,
-            images,
-            model: selectedModel,
-            thinkingLevel: selectedThinkingLevel,
-          })
-          .then(() => {
-            console.log("[sendMessage] prompt accepted")
-          })
-          .catch((err) => {
-            if (!isMountedRef.current) return
-            setError(err instanceof Error ? err.message : "Failed to send message")
-            setSessionStatus(currentSessionId, "error")
-            console.error("[sendMessage] Failed to send message:", err)
-          })
+        await bridge.agent.prompt({
+          sessionID: currentSessionId,
+          directory,
+          text: promptText,
+          images,
+          model: selectedModel,
+          thinkingLevel: selectedThinkingLevel,
+        })
+        console.log("[sendMessage] prompt accepted")
       } catch (err) {
+        if (!isMountedRef.current) return
         setError(err instanceof Error ? err.message : "Failed to send message")
         setSessionStatus(currentSessionId, "error")
         console.error("Failed to send message:", err)
+        throw err
       }
     },
     [currentSessionId, currentSession, messages, setError, setSessionStatus, setSessionError],

--- a/apps/desktop/src/lib/tool-registry.tsx
+++ b/apps/desktop/src/lib/tool-registry.tsx
@@ -1,23 +1,21 @@
 import type { ReactNode, FC } from "react"
 import type { ToolState } from "@/context/session-store"
+import { CheckSquare, Record, Pallete2 } from "@solar-icons/react"
 import {
-  Monitor,
-  Magnifer,
-  Global,
+  Terminal,
+  Search,
+  Globe,
   Glasses,
-  Code,
-  AddSquare,
-  FolderPathConnect,
-  Bolt,
+  PencilLine,
+  FilePlus2,
+  FolderTree,
+  Bot,
   Settings,
   ClipboardList,
-  CheckSquare,
-  Record,
-  Pallete2,
-  MagicStick,
-  QuestionCircle,
-} from "@solar-icons/react"
-import { Streamdown } from "streamdown"
+  Sparkles,
+  CircleHelp,
+} from "lucide-react"
+import { diffLines } from "diff"
 import { cn } from "@/lib/utils"
 
 // Tool props passed to render functions
@@ -43,6 +41,7 @@ type IconComponent = FC<{ size?: number; className?: string }>
 export interface ToolConfig {
   icon: IconComponent
   title: (props: ToolRenderProps) => string
+  expandedTitle?: (props: ToolRenderProps) => string
   chipLabel?: (props: ToolRenderProps) => string | undefined
   subtitle?: (props: ToolRenderProps) => ReactNode | StructuredSubtitle
   content?: (props: ToolRenderProps) => ReactNode
@@ -74,75 +73,47 @@ const getInput = (props: ToolRenderProps) => ({
     props.input.new ??
     props.input.after) as string | undefined,
   content: props.input.content as string | undefined,
+  offset: props.input.offset as number | undefined,
+  limit: props.input.limit as number | undefined,
 })
 
 // Get filename from path
 const filename = (path?: string) => path?.split("/").pop() || ""
 
-// Language map for file extensions
-const LANG_MAP: Record<string, string> = {
-  ts: "typescript",
-  tsx: "tsx",
-  js: "javascript",
-  jsx: "jsx",
-  py: "python",
-  rb: "ruby",
-  rs: "rust",
-  go: "go",
-  java: "java",
-  kt: "kotlin",
-  swift: "swift",
-  c: "c",
-  cpp: "cpp",
-  h: "c",
-  hpp: "cpp",
-  cs: "csharp",
-  php: "php",
-  html: "html",
-  css: "css",
-  scss: "scss",
-  less: "less",
-  json: "json",
-  yaml: "yaml",
-  yml: "yaml",
-  md: "markdown",
-  sql: "sql",
-  sh: "bash",
-  bash: "bash",
-  zsh: "bash",
-  fish: "fish",
-  ps1: "powershell",
-  dockerfile: "dockerfile",
-  toml: "toml",
-  xml: "xml",
-  vue: "vue",
-  svelte: "svelte",
+function PlainToolOutput({ text }: { text: string }) {
+  return (
+    <pre className="text-xs font-mono leading-relaxed whitespace-pre-wrap break-words text-[#e2e2e2]">
+      {text}
+    </pre>
+  )
 }
 
-// Get language from file extension for syntax highlighting
-const getLanguage = (path?: string, content?: string): string => {
-  // Try to detect from file extension first
-  if (path) {
-    const ext = path.split(".").pop()?.toLowerCase()
-    if (ext && LANG_MAP[ext]) return LANG_MAP[ext]
-  }
-
-  // Fallback: detect from content
-  if (content) {
-    const trimmed = content.trimStart()
-    if (trimmed.startsWith("<!DOCTYPE html") || trimmed.startsWith("<html")) return "html"
-    if (trimmed.startsWith("<?xml")) return "xml"
-    if (trimmed.startsWith("{") || trimmed.startsWith("[")) return "json"
-    if (trimmed.startsWith("<!-") && trimmed.includes("<template")) return "vue"
-    if (trimmed.startsWith("---")) return "yaml"
-    if (trimmed.startsWith("#!") && trimmed.includes("python")) return "python"
-    if (trimmed.startsWith("#!") && (trimmed.includes("bash") || trimmed.includes("sh")))
-      return "bash"
-    if (trimmed.startsWith("package ") && trimmed.includes("func ")) return "go"
-    if (trimmed.startsWith("use ") || trimmed.includes("fn ")) return "rust"
-  }
-
-  return "text"
+function InlineDiff({ diff }: { diff: string }) {
+  const lines = diff.split(/\r\n|\r|\n/)
+  return (
+    <pre className="text-xs font-mono leading-relaxed whitespace-pre-wrap break-words">
+      {lines.map((line, index) => {
+        const isFileMeta = line.startsWith("+++") || line.startsWith("---")
+        const isHunk = line.startsWith("@@")
+        const isAdd = line.startsWith("+") && !line.startsWith("+++")
+        const isRemove = line.startsWith("-") && !line.startsWith("---")
+        return (
+          <span
+            key={index}
+            className={cn(
+              "block min-h-[1.35em]",
+              isAdd && "text-emerald-300 bg-emerald-500/10",
+              isRemove && "text-red-300 bg-red-500/10",
+              (isHunk || isFileMeta) && "text-sky-300/80",
+              !isAdd && !isRemove && !isHunk && !isFileMeta && "text-[#d6d6d6]",
+            )}
+          >
+            {line || " "}
+          </span>
+        )
+      })}
+    </pre>
+  )
 }
 
 // Todo type
@@ -157,41 +128,29 @@ export const TOOLS: Record<string, ToolConfig> = {
   read: {
     icon: Glasses,
     title: () => "Read",
+    expandedTitle: () => "Read file",
     chipLabel: (p) => filename(getInput(p).filePath),
     subtitle: (p) => {
       const file = filename(getInput(p).filePath)
-      // Use metadata.preview if available (first 20 lines from backend)
-      const preview = p.metadata?.preview as string | undefined
-      const lines = preview?.split("\n").length ?? p.output?.split("\n").length ?? 0
       if (!file) return undefined
-      return {
-        text: file,
-        suffix:
-          lines > 0 ? <span className="text-muted-foreground/70">({lines} lines)</span> : undefined,
-      }
+      return { text: file }
     },
     content: (p) => {
-      const { filePath } = getInput(p)
       // Prefer metadata.preview for display (more concise)
       const content = (p.metadata?.preview as string) ?? p.output
       if (!content) return null
 
-      const lang = getLanguage(filePath, content)
       const truncated =
         content.length > 3000 ? content.slice(0, 3000) + "\n// ... truncated" : content
-      const markdown = "```" + lang + "\n" + truncated + "\n```"
 
-      return (
-        <div className="text-xs">
-          <Streamdown>{markdown}</Streamdown>
-        </div>
-      )
+      return <PlainToolOutput text={truncated} />
     },
   },
 
   edit: {
-    icon: Code,
-    title: () => "Edit",
+    icon: PencilLine,
+    title: () => "Edited",
+    expandedTitle: () => "Edited file",
     chipLabel: (p) => filename(getInput(p).filePath),
     subtitle: (p) => {
       const { filePath } = getInput(p)
@@ -214,18 +173,13 @@ export const TOOLS: Record<string, ToolConfig> = {
       const diff = p.metadata?.diff as string | undefined
       if (!diff) return null
 
-      const markdown = "```diff\n" + diff + "\n```"
-      return (
-        <div className="text-xs [&_pre]:!bg-transparent [&_code]:!bg-transparent [&_pre]:!m-0 [&_pre]:!p-0">
-          <Streamdown>{markdown}</Streamdown>
-        </div>
-      )
+      return <InlineDiff diff={diff} />
     },
   },
 
   bash: {
-    icon: Monitor,
-    title: () => "Shell",
+    icon: Terminal,
+    title: () => "Ran shell",
     chipLabel: (p) => {
       const desc = p.metadata?.description as string | undefined
       const { description, command } = getInput(p)
@@ -260,7 +214,7 @@ export const TOOLS: Record<string, ToolConfig> = {
           {command && (
             <div className="flex items-start gap-2 font-mono text-xs">
               <span className="text-muted-foreground/50 select-none shrink-0">$</span>
-              <code className="text-foreground/90 break-all whitespace-pre-wrap">{command}</code>
+              <code className="text-[#e2e2e2] break-all whitespace-pre-wrap">{command}</code>
             </div>
           )}
           {output && (
@@ -268,7 +222,7 @@ export const TOOLS: Record<string, ToolConfig> = {
               className={cn(
                 "text-xs font-mono leading-relaxed max-h-40 overflow-auto",
                 "whitespace-pre-wrap break-words",
-                hasError ? "text-red-400/80" : "text-muted-foreground",
+                hasError ? "text-red-300" : "text-[#d6d6d6]",
               )}
             >
               {output.length > 2000 ? output.slice(0, 2000) + "\n..." : output}
@@ -280,8 +234,9 @@ export const TOOLS: Record<string, ToolConfig> = {
   },
 
   write: {
-    icon: AddSquare,
-    title: () => "Write",
+    icon: FilePlus2,
+    title: () => "Wrote",
+    expandedTitle: () => "Wrote file",
     chipLabel: (p) => filename(getInput(p).filePath),
     subtitle: (p) => {
       const { filePath, content } = getInput(p)
@@ -294,25 +249,46 @@ export const TOOLS: Record<string, ToolConfig> = {
       }
     },
     content: (p) => {
-      const { filePath, content } = getInput(p)
+      const { content } = getInput(p)
       if (!content) return null
 
-      const lang = getLanguage(filePath, content)
       const truncated =
         content.length > 3000 ? content.slice(0, 3000) + "\n// ... truncated" : content
-      const markdown = "```" + lang + "\n" + truncated + "\n```"
+      const parts = diffLines("", truncated)
 
       return (
-        <div className="text-xs [&_pre]:!bg-transparent [&_code]:!bg-transparent [&_pre]:!m-0 [&_pre]:!p-0">
-          <Streamdown>{markdown}</Streamdown>
-        </div>
+        <pre className="text-xs font-mono leading-relaxed whitespace-pre-wrap break-words">
+          {parts.flatMap((part, partIndex) =>
+            part.value.split(/(\r\n|\r|\n)/).reduce<ReactNode[]>((nodes, segment, index, segments) => {
+              if (segment === "\n" || segment === "\r" || segment === "\r\n") return nodes
+              if (segment === "" && index === segments.length - 1) return nodes
+              const lineBreak = index < segments.length - 1 ? "\n" : ""
+              nodes.push(
+                <span
+                  key={`${partIndex}-${index}`}
+                  className={cn(
+                    "block min-h-[1.35em]",
+                    part.added && "text-emerald-300 bg-emerald-500/10",
+                    part.removed && "text-red-300 bg-red-500/10",
+                    !part.added && !part.removed && "text-[#e2e2e2]",
+                  )}
+                >
+                  {part.added ? "+ " : part.removed ? "- " : "  "}
+                  {segment}
+                  {lineBreak}
+                </span>,
+              )
+              return nodes
+            }, []),
+          )}
+        </pre>
       )
     },
   },
 
   todowrite: {
     icon: ClipboardList,
-    title: () => "To-dos",
+    title: () => "Updated to-dos",
     subtitle: (p) => {
       const todos = p.input.todos as Todo[] | undefined
       if (!todos?.length) return undefined
@@ -348,8 +324,8 @@ export const TOOLS: Record<string, ToolConfig> = {
   },
 
   glob: {
-    icon: FolderPathConnect,
-    title: () => "Glob",
+    icon: FolderTree,
+    title: () => "Found files",
     chipLabel: (p) => getInput(p).pattern?.slice(0, 20),
     subtitle: (p) => {
       const pattern = getInput(p).pattern
@@ -368,17 +344,12 @@ export const TOOLS: Record<string, ToolConfig> = {
       return pattern
     },
     content: (p) =>
-      p.output && (
-        <pre className="text-xs text-muted-foreground max-h-40 overflow-auto">
-          {p.output.slice(0, 1000)}
-          {p.output.length > 1000 && "..."}
-        </pre>
-      ),
+      p.output && <PlainToolOutput text={p.output.length > 1000 ? `${p.output.slice(0, 1000)}...` : p.output} />,
   },
 
   list: {
-    icon: FolderPathConnect,
-    title: () => "List",
+    icon: FolderTree,
+    title: () => "Listed",
     chipLabel: (p) => filename(getInput(p).filePath) || "directory",
     subtitle: (p) => {
       const { filePath } = getInput(p)
@@ -398,17 +369,12 @@ export const TOOLS: Record<string, ToolConfig> = {
       return path
     },
     content: (p) =>
-      p.output && (
-        <pre className="text-xs text-muted-foreground max-h-40 overflow-auto font-mono">
-          {p.output.slice(0, 1500)}
-          {p.output.length > 1500 && "..."}
-        </pre>
-      ),
+      p.output && <PlainToolOutput text={p.output.length > 1500 ? `${p.output.slice(0, 1500)}...` : p.output} />,
   },
 
   grep: {
-    icon: Magnifer,
-    title: () => "Grep",
+    icon: Search,
+    title: () => "Searched",
     chipLabel: (p) => getInput(p).pattern?.slice(0, 20),
     subtitle: (p) => {
       const pattern = getInput(p).pattern
@@ -427,17 +393,12 @@ export const TOOLS: Record<string, ToolConfig> = {
       return pattern
     },
     content: (p) =>
-      p.output && (
-        <pre className="text-xs text-muted-foreground max-h-40 overflow-auto">
-          {p.output.slice(0, 1000)}
-          {p.output.length > 1000 && "..."}
-        </pre>
-      ),
+      p.output && <PlainToolOutput text={p.output.length > 1000 ? `${p.output.slice(0, 1000)}...` : p.output} />,
   },
 
   webfetch: {
-    icon: Global,
-    title: () => "Fetch",
+    icon: Globe,
+    title: () => "Fetched",
     chipLabel: (p) => {
       const url = getInput(p).url
       try {
@@ -466,22 +427,19 @@ export const TOOLS: Record<string, ToolConfig> = {
         <div className="space-y-2">
           {url && (
             <div className="text-xs">
-              <span className="text-muted-foreground/60">URL: </span>
-              <span className="text-blue-400/80 break-all">{url}</span>
+              <span className="text-[#a8a8a8]">URL: </span>
+              <span className="text-sky-300 break-all">{url}</span>
             </div>
           )}
           {prompt && (
             <div className="text-xs">
-              <span className="text-muted-foreground/60">Prompt: </span>
-              <span className="text-foreground/80">{prompt}</span>
+              <span className="text-[#a8a8a8]">Prompt: </span>
+              <span className="text-[#e2e2e2]">{prompt}</span>
             </div>
           )}
           {p.output && (
-            <div className="mt-2 pt-2 border-t border-border/30">
-              <pre className="text-xs text-muted-foreground max-h-48 overflow-auto whitespace-pre-wrap">
-                {p.output.slice(0, 2000)}
-                {p.output.length > 2000 && "\n..."}
-              </pre>
+            <div className="mt-2 pt-2 border-t border-neutral-700/70">
+              <PlainToolOutput text={p.output.length > 2000 ? `${p.output.slice(0, 2000)}\n...` : p.output} />
             </div>
           )}
         </div>
@@ -490,8 +448,8 @@ export const TOOLS: Record<string, ToolConfig> = {
   },
 
   task: {
-    icon: Bolt,
-    title: () => "Task",
+    icon: Bot,
+    title: () => "Ran task",
     chipLabel: (p) => getInput(p).description?.slice(0, 25),
     subtitle: (p) => {
       const { description } = getInput(p)
@@ -524,13 +482,13 @@ export const TOOLS: Record<string, ToolConfig> = {
       return (
         <div className="space-y-2">
           {prompt && (
-            <p className="text-xs text-muted-foreground">
+            <p className="text-xs text-[#d6d6d6]">
               {prompt.slice(0, 200)}
               {prompt.length > 200 && "..."}
             </p>
           )}
           {summary && summary.length > 0 && (
-            <div className="space-y-1 pt-1 border-t border-border/30">
+            <div className="space-y-1 pt-1 border-t border-neutral-700/70">
               {summary.map((s) => (
                 <div key={s.id} className="flex items-center gap-2 text-xs">
                   <span
@@ -554,10 +512,7 @@ export const TOOLS: Record<string, ToolConfig> = {
             </div>
           )}
           {p.output && !summary && (
-            <pre className="text-xs text-muted-foreground max-h-40 overflow-auto">
-              {p.output.slice(0, 500)}
-              {p.output.length > 500 && "..."}
-            </pre>
+            <PlainToolOutput text={p.output.length > 500 ? `${p.output.slice(0, 500)}...` : p.output} />
           )}
         </div>
       )
@@ -566,7 +521,7 @@ export const TOOLS: Record<string, ToolConfig> = {
 
   theme: {
     icon: Pallete2,
-    title: () => "Theme",
+    title: () => "Created theme",
     chipLabel: (p) => {
       const name = p.input.name as string | undefined
       return name?.slice(0, 20)
@@ -626,7 +581,7 @@ export const TOOLS: Record<string, ToolConfig> = {
   },
 
   skill: {
-    icon: MagicStick,
+    icon: Sparkles,
     title: (p) => {
       // Try different possible input keys for skill name
       const name = (p.input.skill ?? p.input.name ?? p.input.skillName) as string | undefined
@@ -642,7 +597,7 @@ export const TOOLS: Record<string, ToolConfig> = {
       const name = (p.input.skill ?? p.input.name ?? p.input.skillName) as string | undefined
       if (!name && Object.keys(p.input).length > 0) {
         return (
-          <pre className="text-xs text-muted-foreground">{JSON.stringify(p.input, null, 2)}</pre>
+          <PlainToolOutput text={JSON.stringify(p.input, null, 2)} />
         )
       }
       return null
@@ -651,7 +606,7 @@ export const TOOLS: Record<string, ToolConfig> = {
 
   // Question tool - displays questions and user's answers
   question: {
-    icon: QuestionCircle,
+    icon: CircleHelp,
     title: (p) => {
       const questions = p.input.questions as Array<{ header?: string }> | undefined
       const firstHeader = questions?.[0]?.header
@@ -756,15 +711,10 @@ export const DEFAULT_TOOL: ToolConfig = {
     return (
       <>
         {hasInput && (
-          <pre className="text-xs text-muted-foreground">
-            {JSON.stringify(p.input, null, 2).slice(0, 500)}
-          </pre>
+          <PlainToolOutput text={JSON.stringify(p.input, null, 2).slice(0, 500)} />
         )}
         {p.output && (
-          <pre className="text-xs text-muted-foreground max-h-40 overflow-auto">
-            {p.output.slice(0, 500)}
-            {p.output.length > 500 && "..."}
-          </pre>
+          <PlainToolOutput text={p.output.length > 500 ? `${p.output.slice(0, 500)}...` : p.output} />
         )}
       </>
     )

--- a/apps/desktop/src/lib/tool-registry.tsx
+++ b/apps/desktop/src/lib/tool-registry.tsx
@@ -259,27 +259,29 @@ export const TOOLS: Record<string, ToolConfig> = {
       return (
         <pre className="text-xs font-mono leading-relaxed whitespace-pre-wrap break-words">
           {parts.flatMap((part, partIndex) =>
-            part.value.split(/(\r\n|\r|\n)/).reduce<ReactNode[]>((nodes, segment, index, segments) => {
-              if (segment === "\n" || segment === "\r" || segment === "\r\n") return nodes
-              if (segment === "" && index === segments.length - 1) return nodes
-              const lineBreak = index < segments.length - 1 ? "\n" : ""
-              nodes.push(
-                <span
-                  key={`${partIndex}-${index}`}
-                  className={cn(
-                    "block min-h-[1.35em]",
-                    part.added && "text-emerald-300 bg-emerald-500/10",
-                    part.removed && "text-red-300 bg-red-500/10",
-                    !part.added && !part.removed && "text-[#e2e2e2]",
-                  )}
-                >
-                  {part.added ? "+ " : part.removed ? "- " : "  "}
-                  {segment}
-                  {lineBreak}
-                </span>,
-              )
-              return nodes
-            }, []),
+            part.value
+              .split(/(\r\n|\r|\n)/)
+              .reduce<ReactNode[]>((nodes, segment, index, segments) => {
+                if (segment === "\n" || segment === "\r" || segment === "\r\n") return nodes
+                if (segment === "" && index === segments.length - 1) return nodes
+                const lineBreak = index < segments.length - 1 ? "\n" : ""
+                nodes.push(
+                  <span
+                    key={`${partIndex}-${index}`}
+                    className={cn(
+                      "block min-h-[1.35em]",
+                      part.added && "text-emerald-300 bg-emerald-500/10",
+                      part.removed && "text-red-300 bg-red-500/10",
+                      !part.added && !part.removed && "text-[#e2e2e2]",
+                    )}
+                  >
+                    {part.added ? "+ " : part.removed ? "- " : "  "}
+                    {segment}
+                    {lineBreak}
+                  </span>,
+                )
+                return nodes
+              }, []),
           )}
         </pre>
       )
@@ -344,7 +346,11 @@ export const TOOLS: Record<string, ToolConfig> = {
       return pattern
     },
     content: (p) =>
-      p.output && <PlainToolOutput text={p.output.length > 1000 ? `${p.output.slice(0, 1000)}...` : p.output} />,
+      p.output && (
+        <PlainToolOutput
+          text={p.output.length > 1000 ? `${p.output.slice(0, 1000)}...` : p.output}
+        />
+      ),
   },
 
   list: {
@@ -369,7 +375,11 @@ export const TOOLS: Record<string, ToolConfig> = {
       return path
     },
     content: (p) =>
-      p.output && <PlainToolOutput text={p.output.length > 1500 ? `${p.output.slice(0, 1500)}...` : p.output} />,
+      p.output && (
+        <PlainToolOutput
+          text={p.output.length > 1500 ? `${p.output.slice(0, 1500)}...` : p.output}
+        />
+      ),
   },
 
   grep: {
@@ -393,7 +403,11 @@ export const TOOLS: Record<string, ToolConfig> = {
       return pattern
     },
     content: (p) =>
-      p.output && <PlainToolOutput text={p.output.length > 1000 ? `${p.output.slice(0, 1000)}...` : p.output} />,
+      p.output && (
+        <PlainToolOutput
+          text={p.output.length > 1000 ? `${p.output.slice(0, 1000)}...` : p.output}
+        />
+      ),
   },
 
   webfetch: {
@@ -439,7 +453,9 @@ export const TOOLS: Record<string, ToolConfig> = {
           )}
           {p.output && (
             <div className="mt-2 pt-2 border-t border-neutral-700/70">
-              <PlainToolOutput text={p.output.length > 2000 ? `${p.output.slice(0, 2000)}\n...` : p.output} />
+              <PlainToolOutput
+                text={p.output.length > 2000 ? `${p.output.slice(0, 2000)}\n...` : p.output}
+              />
             </div>
           )}
         </div>
@@ -512,7 +528,9 @@ export const TOOLS: Record<string, ToolConfig> = {
             </div>
           )}
           {p.output && !summary && (
-            <PlainToolOutput text={p.output.length > 500 ? `${p.output.slice(0, 500)}...` : p.output} />
+            <PlainToolOutput
+              text={p.output.length > 500 ? `${p.output.slice(0, 500)}...` : p.output}
+            />
           )}
         </div>
       )
@@ -596,9 +614,7 @@ export const TOOLS: Record<string, ToolConfig> = {
       // Show input for debugging if no recognized keys
       const name = (p.input.skill ?? p.input.name ?? p.input.skillName) as string | undefined
       if (!name && Object.keys(p.input).length > 0) {
-        return (
-          <PlainToolOutput text={JSON.stringify(p.input, null, 2)} />
-        )
+        return <PlainToolOutput text={JSON.stringify(p.input, null, 2)} />
       }
       return null
     },
@@ -710,11 +726,11 @@ export const DEFAULT_TOOL: ToolConfig = {
     const hasInput = Object.keys(p.input).length > 0
     return (
       <>
-        {hasInput && (
-          <PlainToolOutput text={JSON.stringify(p.input, null, 2).slice(0, 500)} />
-        )}
+        {hasInput && <PlainToolOutput text={JSON.stringify(p.input, null, 2).slice(0, 500)} />}
         {p.output && (
-          <PlainToolOutput text={p.output.length > 500 ? `${p.output.slice(0, 500)}...` : p.output} />
+          <PlainToolOutput
+            text={p.output.length > 500 ? `${p.output.slice(0, 500)}...` : p.output}
+          />
         )}
       </>
     )

--- a/apps/desktop/src/routes/project.$projectId.tsx
+++ b/apps/desktop/src/routes/project.$projectId.tsx
@@ -19,7 +19,7 @@ import { useProjectMutations, useProjectsList } from "@/hooks/use-projects"
 import { useSessions } from "@/hooks/use-sessions"
 import { cn } from "@/lib/utils"
 import { ArrowUp, Monitor, Smartphone } from "@solar-icons/react"
-import { createFileRoute, useNavigate, useParams } from "@tanstack/react-router"
+import { createFileRoute, Outlet, useMatch, useNavigate, useParams } from "@tanstack/react-router"
 import type { FileUIPart } from "ai"
 
 export const Route = createFileRoute("/project/$projectId")({
@@ -28,6 +28,10 @@ export const Route = createFileRoute("/project/$projectId")({
 
 function ProjectComposerPage() {
   const { projectId } = useParams({ from: "/project/$projectId" })
+  const sessionRouteMatch = useMatch({
+    from: "/project/$projectId/session/$sessionId",
+    shouldThrow: false,
+  })
   const navigate = useNavigate()
   const { data: projects = [] } = useProjectsList()
   const { updateProject, touchProject } = useProjectMutations()
@@ -52,6 +56,10 @@ function ProjectComposerPage() {
         params: { projectId: project.id, sessionId },
       })
     }
+  }
+
+  if (sessionRouteMatch) {
+    return <Outlet />
   }
 
   if (!project) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint": "turbo lint",
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
-    "clean": "turbo clean && rm -rf node_modules"
+    "clean": "turbo clean && rm -rf node_modules",
+    "test:prompt-flow": "bun run --cwd apps/desktop test:prompt-flow"
   },
   "devDependencies": {
     "prettier": "^3.7.4",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "typecheck": "turbo typecheck",
     "test": "turbo test",
     "lint": "turbo lint",
+    "test:prompt-flow": "bun run --cwd apps/desktop test:prompt-flow",
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
-    "clean": "turbo clean && rm -rf node_modules",
-    "test:prompt-flow": "bun run --cwd apps/desktop test:prompt-flow"
+    "clean": "turbo clean && rm -rf node_modules"
   },
   "devDependencies": {
     "prettier": "^3.7.4",


### PR DESCRIPTION
## Summary

Hardens the Dilag/Pi prompt flow for project chats and refreshes assistant work/tool rendering in the desktop chat UI.

## Changes

- Commit 1: Harden Pi prompt submission by awaiting preflight, preferring supported default models, fixing nested project session routing, and adding focused prompt-flow regression coverage.
- Commit 2: Group assistant work into a single "Worked for…" disclosure, refine reasoning/tool rows, improve tool labels/diff/read output, and strip expanded skill wrappers from chat names.

## Testing

- `bun run test:prompt-flow`
- `bun run --cwd apps/desktop test -- src/components/blocks/chat/chat-view.test.tsx src/hooks/use-sessions.test.ts`
- `bun run --cwd apps/desktop typecheck`
- Manual Electron check with agent-browser against chat `019e2b97-d17d-77d9-93b3-70b30ff728a9`
