### PR TITLE
Improve generated screen policy and studio prompt flow

### DIFF
--- a/apps/desktop/electron/ipc/design-skill-pack.ts
+++ b/apps/desktop/electron/ipc/design-skill-pack.ts
@@ -1,0 +1,122 @@
+import fsp from "node:fs/promises"
+import path from "node:path"
+import {
+  renderGeneratedScreenOutputRules,
+  renderGeneratedScreenSystemPromptRules,
+  renderHtmlScreenContract,
+} from "@dilag/desktop-bridge"
+import { getDilagSkillsDir, resolveDesignAssetDir } from "./paths.js"
+
+export const DILAG_MOBILE_DESIGN_SKILL_NAME = "dilag-mobile-design"
+export const DILAG_WEB_DESIGN_SKILL_NAME = "dilag-web-design"
+export const DILAG_DESIGN_SKILL_NAMES = {
+  mobile: DILAG_MOBILE_DESIGN_SKILL_NAME,
+  web: DILAG_WEB_DESIGN_SKILL_NAME,
+} as const
+
+export type DilagDesignSkillKind = keyof typeof DILAG_DESIGN_SKILL_NAMES
+
+export interface DilagDesignSkillAssets {
+  commonTemplate: string
+  htmlScreenContractTemplate: string
+  mobileTemplate: string
+  webTemplate: string
+}
+
+export interface DilagDesignSkillEnvironment {
+  DILAG_BRAND_TOKENS?: string
+  DILAG_DOMAIN_HINT?: string
+  DILAG_REFERENCE_URLS?: string
+}
+
+const ENVIRONMENT_FALLBACK = "(none specified - use your judgment based on the user's request)"
+
+export const DILAG_SYSTEM_PROMPT = `You are Dilag, a UI design agent that produces production-grade HTML screen prototypes.
+
+## Workspace invariants
+${renderGeneratedScreenSystemPromptRules()}
+
+## Design workflow
+- For new design requests, use the ${DILAG_WEB_DESIGN_SKILL_NAME} or ${DILAG_MOBILE_DESIGN_SKILL_NAME} skill when instructed by the user message.
+- Never inline full HTML in your assistant reply. Use write/edit, then summarize briefly.`
+
+export async function syncDilagDesignSkills(): Promise<void> {
+  const assetDir = resolveDesignAssetDir()
+  const skillsDir = getDilagSkillsDir()
+  const assets = await readDilagDesignSkillAssets(assetDir)
+
+  await Promise.all(
+    Object.values(DILAG_DESIGN_SKILL_NAMES).map((skillName) =>
+      fsp.mkdir(path.join(skillsDir, skillName), { recursive: true }),
+    ),
+  )
+
+  await Promise.all(
+    (Object.keys(DILAG_DESIGN_SKILL_NAMES) as DilagDesignSkillKind[]).map((kind) =>
+      fsp.writeFile(
+        path.join(skillsDir, DILAG_DESIGN_SKILL_NAMES[kind], "SKILL.md"),
+        renderDesignSkill(kind, assets),
+      ),
+    ),
+  )
+}
+
+export function renderDesignSkill(
+  kind: DilagDesignSkillKind,
+  assets: DilagDesignSkillAssets,
+  environment: DilagDesignSkillEnvironment = readDilagDesignSkillEnvironment(),
+): string {
+  const template = kind === "mobile" ? assets.mobileTemplate : assets.webTemplate
+  const common = renderDesignSkillCommon(assets, environment)
+  return rewriteSkillName(template, DILAG_DESIGN_SKILL_NAMES[kind])
+    .replace("{{COMMON}}", common)
+    .replace("{{BRAND_TOKENS}}", environmentText(environment.DILAG_BRAND_TOKENS))
+    .replace("{{DOMAIN_HINT}}", environmentText(environment.DILAG_DOMAIN_HINT))
+    .replace("{{REFERENCE_URLS}}", environmentText(environment.DILAG_REFERENCE_URLS))
+}
+
+async function readDilagDesignSkillAssets(assetDir: string): Promise<DilagDesignSkillAssets> {
+  const [commonTemplate, htmlScreenContractTemplate, mobileTemplate, webTemplate] =
+    await Promise.all([
+      fsp.readFile(path.join(assetDir, "designer-common.md"), "utf8"),
+      fsp.readFile(path.join(assetDir, "html-screen-contract.md"), "utf8"),
+      fsp.readFile(path.join(assetDir, "mobile-designer-prompt.md"), "utf8"),
+      fsp.readFile(path.join(assetDir, "web-designer-prompt.md"), "utf8"),
+    ])
+
+  return {
+    commonTemplate,
+    htmlScreenContractTemplate,
+    mobileTemplate,
+    webTemplate,
+  }
+}
+
+function renderDesignSkillCommon(
+  assets: DilagDesignSkillAssets,
+  environment: DilagDesignSkillEnvironment,
+): string {
+  const htmlScreenContract = renderHtmlScreenContract(assets.htmlScreenContractTemplate)
+  return assets.commonTemplate
+    .replace("{{HTML_SCREEN_CONTRACT}}", htmlScreenContract)
+    .replaceAll("{{GENERATED_SCREEN_OUTPUT_RULES}}", renderGeneratedScreenOutputRules())
+    .replace("{{BRAND_TOKENS}}", environmentText(environment.DILAG_BRAND_TOKENS))
+    .replace("{{DOMAIN_HINT}}", environmentText(environment.DILAG_DOMAIN_HINT))
+    .replace("{{REFERENCE_URLS}}", environmentText(environment.DILAG_REFERENCE_URLS))
+}
+
+function rewriteSkillName(template: string, skillName: string): string {
+  return template.replace(/^name:\s*[^\n]+$/m, `name: ${skillName}`)
+}
+
+function readDilagDesignSkillEnvironment(): DilagDesignSkillEnvironment {
+  return {
+    DILAG_BRAND_TOKENS: process.env.DILAG_BRAND_TOKENS,
+    DILAG_DOMAIN_HINT: process.env.DILAG_DOMAIN_HINT,
+    DILAG_REFERENCE_URLS: process.env.DILAG_REFERENCE_URLS,
+  }
+}
+
+function environmentText(value: string | undefined): string {
+  return value?.trim() || ENVIRONMENT_FALLBACK
+}

--- a/apps/desktop/electron/ipc/designs.ts
+++ b/apps/desktop/electron/ipc/designs.ts
@@ -1,7 +1,13 @@
 import fs from "node:fs"
 import fsp from "node:fs/promises"
 import path from "node:path"
-import type { DesignFile, Violation } from "@dilag/desktop-bridge"
+import {
+  getGeneratedScreenDirectories,
+  getGeneratedScreenFallbackKey,
+  type DesignFile,
+  type GeneratedScreenDirectory,
+  type Violation,
+} from "@dilag/desktop-bridge"
 
 function extractHtmlAttr(html: string, attr: string): string | null {
   return new RegExp(`${attr}=["']([^"']+)["']`).exec(html)?.[1] ?? null
@@ -51,18 +57,28 @@ export function validateHtml(html: string): Violation[] {
   return violations
 }
 
-async function loadDesignsFromDir(dir: string, seen: Set<string>, out: DesignFile[]) {
-  if (!fs.existsSync(dir)) return
-  for (const entry of await fsp.readdir(dir, { withFileTypes: true })) {
-    const filePath = path.join(dir, entry.name)
+async function loadDesignsFromDir(
+  sessionCwd: string,
+  directory: GeneratedScreenDirectory,
+  seenScreenPaths: Set<string>,
+  out: DesignFile[],
+  currentDir = directory.path,
+) {
+  if (!fs.existsSync(currentDir)) return
+  for (const entry of await fsp.readdir(currentDir, { withFileTypes: true })) {
+    const filePath = path.join(currentDir, entry.name)
     if (entry.isDirectory()) {
-      await loadDesignsFromDir(filePath, seen, out)
+      await loadDesignsFromDir(sessionCwd, directory, seenScreenPaths, out, filePath)
       continue
     }
-    if (!entry.isFile() || !entry.name.endsWith(".html") || seen.has(filePath)) continue
+    if (!entry.isFile() || !entry.name.endsWith(".html")) continue
+
+    const screenPath = getGeneratedScreenFallbackKey(filePath, sessionCwd)
+    if (!screenPath || seenScreenPaths.has(screenPath)) continue
+
     const html = await fsp.readFile(filePath, "utf8")
     const stat = await fsp.stat(filePath)
-    seen.add(filePath)
+    seenScreenPaths.add(screenPath)
     out.push({
       filename: entry.name,
       file_path: filePath,
@@ -77,8 +93,10 @@ async function loadDesignsFromDir(dir: string, seen: Set<string>, out: DesignFil
 
 export async function loadDesignsForSession(sessionCwd: string): Promise<DesignFile[]> {
   const designs: DesignFile[] = []
-  const seen = new Set<string>()
-  await loadDesignsFromDir(path.join(sessionCwd, ".designs"), seen, designs)
+  const seenScreenPaths = new Set<string>()
+  for (const directory of getGeneratedScreenDirectories(sessionCwd)) {
+    await loadDesignsFromDir(sessionCwd, directory, seenScreenPaths, designs)
+  }
   return designs.sort((a, b) => a.modified_at - b.modified_at)
 }
 

--- a/apps/desktop/electron/ipc/host.ts
+++ b/apps/desktop/electron/ipc/host.ts
@@ -1,9 +1,11 @@
 import { app, dialog, ipcMain, shell, type BrowserWindow } from "electron"
 import { autoUpdater } from "electron-updater"
 import fsp from "node:fs/promises"
-import path from "node:path"
 import { CHANNELS } from "../shared/channels.js"
-import type { UpdateDownloadEvent } from "@dilag/desktop-bridge"
+import {
+  getCanonicalGeneratedScreenDirectory,
+  type UpdateDownloadEvent,
+} from "@dilag/desktop-bridge"
 import { copyHtmlFiles, loadDesignsForSession, validateHtml } from "./designs.js"
 import {
   abortAgentSession,
@@ -202,8 +204,8 @@ export function registerHostHandlers(getWindow: () => BrowserWindow | null) {
     CHANNELS.designs.copyBetweenSessions,
     async (_event, args: { sourceCwd: string; destCwd: string }) => {
       await copyHtmlFiles(
-        path.join(args.sourceCwd, ".designs"),
-        path.join(args.destCwd, ".designs"),
+        getCanonicalGeneratedScreenDirectory(args.sourceCwd),
+        getCanonicalGeneratedScreenDirectory(args.destCwd),
       )
     },
   )

--- a/apps/desktop/electron/ipc/pi.ts
+++ b/apps/desktop/electron/ipc/pi.ts
@@ -24,7 +24,8 @@ import path from "node:path"
 import { randomUUID } from "node:crypto"
 import { Type } from "typebox"
 import { CHANNELS } from "../shared/channels.js"
-import { getDilagSkillsDir, getPiAgentDir, resolveDesignAssetDir } from "./paths.js"
+import { DILAG_SYSTEM_PROMPT, syncDilagDesignSkills } from "./design-skill-pack.js"
+import { getDilagSkillsDir, getPiAgentDir } from "./paths.js"
 
 type EventSender = (channel: string, event: unknown) => void
 
@@ -100,19 +101,6 @@ const PREFERRED_DEFAULT_MODELS = [
 ]
 const DEBUG_PI_SMOKE = process.env.DILAG_DEBUG_PI === "1"
 
-const DILAG_SYSTEM_PROMPT = `You are Dilag, a UI design agent that produces production-grade HTML screen prototypes.
-
-## Workspace invariants
-- The current working directory is the active Dilag project directory. Treat it as the only workspace.
-- Create and edit design files inside this directory only. Do not write to the user home directory, parent directories, or absolute paths outside the current working directory.
-- Write every generated screen to .designs/<kebab-name>.html. Do not use screens/, the project root, or any other folder for generated screens.
-- The write tool creates parent directories automatically; do not run mkdir just to create .designs/.
-- Before editing an existing screen, inspect the project files and prefer .designs/*.html.
-
-## Design workflow
-- For new design requests, use the dilag-web-design or dilag-mobile-design skill when instructed by the user message.
-- Never inline full HTML in your assistant reply. Use write/edit, then summarize briefly.`
-
 let eventSender: EventSender | undefined
 let piModulePromise: Promise<typeof import("@earendil-works/pi-coding-agent")> | undefined
 
@@ -144,6 +132,7 @@ export async function stopAgentRuntime(): Promise<void> {
   await Promise.all(
     Array.from(sessions.values()).map(async (runtime) => {
       runtime.unsubscribe()
+      runtime.session.clearQueue()
       await runtime.session.abort().catch(() => undefined)
     }),
   )
@@ -308,6 +297,7 @@ export async function promptAgentSession(args: {
   images?: Array<{ type: "image"; data: string; mimeType: string }>
   model?: RequestedAgentModel | null
   thinkingLevel?: AgentThinkingLevel
+  streamingBehavior?: "steer" | "followUp"
 }): Promise<void> {
   const runtime = await ensureRuntimeSession(
     args.sessionID,
@@ -343,6 +333,7 @@ export async function promptAgentSession(args: {
     void runtime.session
       .prompt(args.text, {
         images: args.images,
+        streamingBehavior: args.streamingBehavior,
         preflightResult: (success) => {
           debugPiSmoke("prompt.preflight", { sessionID: runtime.id, success })
           if (!success) return
@@ -367,6 +358,7 @@ export async function promptAgentSession(args: {
 
 export async function abortAgentSession(args: { sessionID: string }): Promise<void> {
   const runtime = getRuntimeSession(args.sessionID)
+  runtime.session.clearQueue()
   await runtime.session.abort()
   emitSessionIdle(runtime.id)
 }
@@ -531,7 +523,7 @@ async function createPiSession(
   requestedModel?: RequestedAgentModel | null,
   thinkingLevel?: AgentThinkingLevel,
 ) {
-  await syncDilagSkills()
+  await syncDilagDesignSkills()
   const pi = await loadPi()
   const registry = await createModelRegistry()
   const model = requestedModel
@@ -564,47 +556,6 @@ async function createPiSession(
     uiContext: createBridgeUiContext(),
   })
   return result
-}
-
-async function syncDilagSkills(): Promise<void> {
-  const assetDir = resolveDesignAssetDir()
-  const skillsDir = getDilagSkillsDir()
-  const mobileSkillDir = path.join(skillsDir, "dilag-mobile-design")
-  const webSkillDir = path.join(skillsDir, "dilag-web-design")
-
-  const [common, mobile, web] = await Promise.all([
-    fsp.readFile(path.join(assetDir, "designer-common.md"), "utf8"),
-    fsp.readFile(path.join(assetDir, "mobile-designer-prompt.md"), "utf8"),
-    fsp.readFile(path.join(assetDir, "web-designer-prompt.md"), "utf8"),
-  ])
-
-  await Promise.all([
-    fsp.mkdir(mobileSkillDir, { recursive: true }),
-    fsp.mkdir(webSkillDir, { recursive: true }),
-  ])
-
-  await Promise.all([
-    fsp.writeFile(
-      path.join(mobileSkillDir, "SKILL.md"),
-      renderDesignSkill(mobile, common).replace("name: mobile-design", "name: dilag-mobile-design"),
-    ),
-    fsp.writeFile(
-      path.join(webSkillDir, "SKILL.md"),
-      renderDesignSkill(web, common).replace("name: web-design", "name: dilag-web-design"),
-    ),
-  ])
-}
-
-function renderDesignSkill(template: string, common: string): string {
-  const fallback = "(none specified - use your judgment based on the user's request)"
-  const brand = process.env.DILAG_BRAND_TOKENS?.trim() || fallback
-  const domain = process.env.DILAG_DOMAIN_HINT?.trim() || fallback
-  const refs = process.env.DILAG_REFERENCE_URLS?.trim() || fallback
-  return template
-    .replace("{{COMMON}}", common)
-    .replace("{{BRAND_TOKENS}}", brand)
-    .replace("{{DOMAIN_HINT}}", domain)
-    .replace("{{REFERENCE_URLS}}", refs)
 }
 
 function bindRuntimeSession(session: AgentSession, cwd: string): RuntimeSession {
@@ -846,6 +797,11 @@ function handlePiSessionEvent(runtime: RuntimeSession, event: AgentSessionEvent)
     const phase =
       event.type === "message_start" ? "start" : event.type === "message_end" ? "end" : "update"
     emitMessage(runtime, event.message as PiMessage, phase)
+    return
+  }
+
+  if (event.type === "queue_update") {
+    emitPromptQueueUpdate(runtime.id, event.steering, event.followUp)
     return
   }
 
@@ -1210,6 +1166,21 @@ function humanizeProviderName(id: string): string {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ")
+}
+
+function emitPromptQueueUpdate(
+  sessionID: string,
+  steering: readonly string[],
+  followUp: readonly string[],
+) {
+  emitAgentEvent({
+    type: "prompt.queue.updated",
+    properties: {
+      sessionID,
+      steering: [...steering],
+      followUp: [...followUp],
+    },
+  })
 }
 
 function emitSessionStatus(sessionID: string, status: "running" | "idle" | "error") {

--- a/apps/desktop/electron/ipc/sessions.ts
+++ b/apps/desktop/electron/ipc/sessions.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs"
 import fsp from "node:fs/promises"
 import path from "node:path"
-import type { SessionMeta } from "@dilag/desktop-bridge"
+import { getCanonicalGeneratedScreenDirectory, type SessionMeta } from "@dilag/desktop-bridge"
 import { getSessionsDir, getSessionsFile } from "./paths.js"
 
 type SessionsStore = { sessions: SessionMeta[] }
@@ -21,7 +21,7 @@ async function saveSessionsStore(store: SessionsStore) {
 
 export async function createSessionDir(sessionId: string): Promise<string> {
   const sessionDir = path.join(getSessionsDir(), sessionId)
-  await fsp.mkdir(path.join(sessionDir, ".designs"), { recursive: true })
+  await fsp.mkdir(getCanonicalGeneratedScreenDirectory(sessionDir), { recursive: true })
   return sessionDir
 }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -89,7 +89,7 @@ async function createWindow() {
     show: false,
     // macOS: hide title bar and keep traffic lights inset to match the renderer chrome.
     titleBarStyle: "hiddenInset",
-    trafficLightPosition: { x: 16, y: 22 },
+    trafficLightPosition: { x: 16, y: 15 },
     // Hex approximation of oklch(0.14 0.01 250) used by the renderer's CSS.
     backgroundColor: "#070A0D",
     webPreferences: {

--- a/apps/desktop/resources/design-assets/designer-common.md
+++ b/apps/desktop/resources/design-assets/designer-common.md
@@ -1,10 +1,12 @@
+{{HTML_SCREEN_CONTRACT}}
+
 ## Output
 
 Use the `write` tool — never inline HTML in your reply.
 
-- Path: `.designs/<kebab-name>.html` relative to the current working directory
-- Do not write generated screens to `screens/`, the project root, the user home directory, or any absolute path outside the current working directory
-- Set `data-title="<Screen Name>"` on the `<html>` tag
+{{GENERATED_SCREEN_OUTPUT_RULES}}
+
+- Set `data-title="<Screen Name>"` and `data-screen-type="mobile|web"` on the `<html>` tag
 - All screens share one palette, one type stack, one tone
 
 ## Before You Code

--- a/apps/desktop/resources/design-assets/html-screen-contract.md
+++ b/apps/desktop/resources/design-assets/html-screen-contract.md
@@ -1,0 +1,31 @@
+## HTML Screen Contract
+
+When the user gives a vague design prompt, treat this contract as the source of truth for what Dilag can display.
+
+### Required output location
+
+{{GENERATED_SCREEN_OUTPUT_RULES}}
+
+### Required HTML metadata
+
+Every screen file must be a complete standalone HTML document and include:
+
+```html
+<html lang="en" data-title="Readable Screen Name" data-screen-type="mobile"></html>
+```
+
+Use `data-screen-type="mobile"` for mobile screens and `data-screen-type="web"` for web screens.
+
+### Display constraints
+
+- Mobile screens: fixed `393px × 852px`, `overflow: hidden`, iPhone-safe-area aware.
+- Web screens: responsive but complete as a standalone prototype.
+- Use CDN Tailwind and Iconify as shown in the Dilag design skills.
+- Do not depend on local build steps, React, Vite, Next.js, or app source files.
+
+### Avoid
+
+- Decorative CSS animations, `@keyframes`, Tailwind `animate-*`, or initial `opacity: 0`.
+- Real navigation URLs; use `href="#"`.
+- Emoji as icons; use Iconify.
+- Generic gradients, identical cards everywhere, redundant CTAs, or stock dashboard templates.

--- a/apps/desktop/resources/design-assets/mobile-designer-prompt.md
+++ b/apps/desktop/resources/design-assets/mobile-designer-prompt.md
@@ -49,7 +49,7 @@ Numbers in circles are forgettable. Make achievements feel like real rewards:
 
 ```html
 <!DOCTYPE html>
-<html lang="en" data-title="Screen Name">
+<html lang="en" data-title="Screen Name" data-screen-type="mobile">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=393, initial-scale=1.0" />

--- a/apps/desktop/resources/design-assets/web-designer-prompt.md
+++ b/apps/desktop/resources/design-assets/web-designer-prompt.md
@@ -35,7 +35,7 @@ Mobile-first; enhance with `sm: md: lg: xl:`. Container uses `max-w-7xl mx-auto`
 
 ```html
 <!DOCTYPE html>
-<html lang="en" data-title="Screen Name">
+<html lang="en" data-title="Screen Name" data-screen-type="web">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/desktop/src/components/blocks/chat/chat-view.tsx
+++ b/apps/desktop/src/components/blocks/chat/chat-view.tsx
@@ -15,7 +15,6 @@ import {
   ClipboardText,
   CloseCircle,
   DangerTriangle,
-  Stop,
   ArrowUp,
   MagicStick,
   BranchingPathsUp,
@@ -32,6 +31,7 @@ import {
   useSessionError,
   useSessionRevert,
   useSessionStore,
+  useQueuedFollowUps,
   type SessionStatus,
   type Message as SessionMessage,
 } from "@/context/session-store"
@@ -42,7 +42,6 @@ import { MessagePart } from "./message-part"
 import {
   Conversation,
   ConversationContent,
-  ConversationEmptyState,
   ConversationScrollButton,
 } from "@/components/ai-elements/conversation"
 import {
@@ -78,6 +77,7 @@ import type { MessagePart as MessagePartType } from "@/context/session-store"
 import type { FileNode } from "@dilag/desktop-bridge"
 import { toast } from "sonner"
 import { bridge } from "@/lib/bridge"
+import { queuedFollowUpPreview, type PromptDeliveryOutcome } from "@/lib/prompt-delivery"
 
 const FILE_MENTION_SEARCH_DEBOUNCE_MS = 150
 const FILE_MENTION_SEARCH_LIMIT = 20
@@ -752,11 +752,16 @@ function ChatInputArea({
   sendMessage,
   stopSession,
   sessionCwd,
+  queuedFollowUps,
 }: {
   isLoading: boolean
-  sendMessage: (message: string, files?: import("ai").FileUIPart[]) => Promise<void>
+  sendMessage: (
+    message: string,
+    files?: import("ai").FileUIPart[],
+  ) => Promise<PromptDeliveryOutcome | undefined>
   stopSession: () => Promise<void>
   sessionCwd: string | null
+  queuedFollowUps: string[]
 }) {
   const composerTextareaId = useId()
   const { textInput, attachments, screenRefs } = usePromptInputController()
@@ -772,6 +777,7 @@ function ChatInputArea({
   const hasComposerReferences =
     attachments.files.length > 0 || screenRefs.references.length > 0 || mentionedFiles.length > 0
   const hasSubmittableInput = hasInput || hasComposerReferences
+  const hasRuntimeQueuedFollowUps = queuedFollowUps.length > 0
   const { pendingMessage, clearPendingMessage } = usePendingMessage()
 
   // Handle pending messages from server error overlay or other sources
@@ -981,8 +987,6 @@ function ChatInputArea({
   }, [mentionedFiles, sessionCwd])
 
   const handleSubmit = async (text: string, files?: import("ai").FileUIPart[]) => {
-    if (isLoading) return
-
     const trimmedText = text.trim()
     const inputFiles = files ?? []
     const hasMentionedFiles = mentionedFiles.length > 0
@@ -1017,19 +1021,19 @@ function ChatInputArea({
     }
 
     try {
-      await sendMessage(trimmedText, mergedFiles.length > 0 ? mergedFiles : undefined)
+      const delivery = await sendMessage(
+        trimmedText,
+        mergedFiles.length > 0 ? mergedFiles : undefined,
+      )
+      if (delivery?.status === "queued") {
+        toast.success("Queued follow-up message")
+      }
       setMentionedFiles([])
       setMentionOpen(false)
       setMentionSearchResults([])
       setHighlightedMentionIndex(0)
     } catch {
       toast.error("Failed to send message")
-    }
-  }
-
-  const handleButtonClick = () => {
-    if (isLoading) {
-      stopSession()
     }
   }
 
@@ -1057,6 +1061,38 @@ function ChatInputArea({
       <div className="space-y-2">
         {/* Gradient fade */}
         <div className="absolute inset-x-0 -top-12 h-12 bg-gradient-to-t from-background to-transparent pointer-events-none" />
+
+        {(isLoading || hasRuntimeQueuedFollowUps) && (
+          <div className="rounded-xl border border-border/60 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-2">
+                <ClockCircle size={14} className="shrink-0 text-primary" />
+                <span className="truncate">
+                  {isLoading
+                    ? "Agent is working. Send now to queue a follow-up."
+                    : "Follow-up queued."}
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={() => stopSession()}
+                className="shrink-0 font-medium text-foreground/80 transition-colors hover:text-foreground"
+              >
+                Stop
+              </button>
+            </div>
+            {hasRuntimeQueuedFollowUps && (
+              <div className="mt-2 space-y-1.5 border-t border-border/50 pt-2">
+                {queuedFollowUps.map((prompt, index) => (
+                  <div key={`${index}-${prompt}`} className="flex gap-2 text-foreground/75">
+                    <span className="shrink-0 text-muted-foreground">Queued</span>
+                    <span className="min-w-0 truncate">{queuedFollowUpPreview(prompt)}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
 
         <PromptInput
           onSubmit={async ({ text, files }) => handleSubmit(text, files)}
@@ -1101,7 +1137,6 @@ function ChatInputArea({
               id={composerTextareaId}
               data-chat-composer-textarea
               placeholder="Describe what to design..."
-              disabled={isLoading}
               className="min-h-[56px] max-h-[200px]"
               onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
                 syncCaretPosition(event.currentTarget)
@@ -1152,19 +1187,16 @@ function ChatInputArea({
             <div className="flex items-center gap-1">
               <PromptInputAddAttachmentButton />
               <PromptInputSubmit
-                disabled={!hasSubmittableInput && !isLoading}
-                onClick={isLoading ? handleButtonClick : undefined}
-                type={isLoading ? "button" : "submit"}
+                disabled={!hasSubmittableInput}
+                aria-label={isLoading ? "Queue follow-up" : "Send message"}
                 className={cn(
                   "size-9 rounded-xl transition-all duration-200",
-                  isLoading
-                    ? "bg-destructive/90 text-destructive-foreground hover:bg-destructive shadow-lg shadow-destructive/25"
-                    : hasSubmittableInput
-                      ? "bg-primary text-primary-foreground shadow-lg shadow-primary/25"
-                      : "bg-muted text-muted-foreground",
+                  hasSubmittableInput
+                    ? "bg-primary text-primary-foreground shadow-lg shadow-primary/25"
+                    : "bg-muted text-muted-foreground",
                 )}
               >
-                {isLoading ? <Stop size={14} className="fill-current" /> : <ArrowUp size={16} />}
+                {isLoading ? <ClockCircle size={16} /> : <ArrowUp size={16} />}
               </PromptInputSubmit>
             </div>
           </PromptInputFooter>
@@ -1254,6 +1286,7 @@ export function ChatView() {
 
   // Get revert state for current session
   const sessionRevert = useSessionRevert(currentSessionId)
+  const queuedFollowUps = useQueuedFollowUps(currentSessionId)
 
   // Handler for forking from a message
   const handleFork = useCallback(
@@ -1338,15 +1371,9 @@ export function ChatView() {
         {/* Messages area - flex-1 + min-h-0 allows proper flex shrinking */}
         <Conversation className="flex-1 min-h-0">
           <ConversationContent className="px-4">
-            {messages.length === 0 && !hasPendingPrompt ? (
-              <ConversationEmptyState>
-                <p className="text-[13px] text-muted-foreground/50">
-                  Describe your app to start designing
-                </p>
-              </ConversationEmptyState>
-            ) : messages.length === 0 && hasPendingPrompt ? (
+            {messages.length === 0 && hasPendingPrompt ? (
               <PendingPrompt />
-            ) : (
+            ) : messages.length === 0 ? null : (
               messages.map((message, index) => {
                 // Check if this is the last assistant message
                 const isLastAssistant =
@@ -1405,6 +1432,7 @@ export function ChatView() {
             sendMessage={sendMessage}
             stopSession={stopSession}
             sessionCwd={currentSession?.cwd ?? null}
+            queuedFollowUps={queuedFollowUps}
           />
         </div>
 

--- a/apps/desktop/src/components/blocks/layout/app-sidebar.tsx
+++ b/apps/desktop/src/components/blocks/layout/app-sidebar.tsx
@@ -28,7 +28,6 @@ import {
   SidebarGroup,
   SidebarGroupLabel,
   SidebarGroupContent,
-  SidebarTrigger,
   useSidebar,
 } from "@dilag/ui/sidebar"
 import {
@@ -40,8 +39,9 @@ import {
 } from "@dilag/ui/dropdown-menu"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@dilag/ui/tooltip"
 import { AuthSettings } from "@/components/blocks/auth/auth-settings"
-import { useProjectMutations, useProjectsList, getDefaultProject } from "@/hooks/use-projects"
+import { useProjectMutations, useProjectsList } from "@/hooks/use-projects"
 import { useSessions } from "@/hooks/use-sessions"
+import { useNewDesignFlow } from "@/features/new-design/use-new-design-flow"
 import { bridge } from "@/lib/bridge"
 import type { ProjectMeta } from "@dilag/desktop-bridge"
 import type { SessionMeta } from "@/context/session-store"
@@ -65,10 +65,10 @@ function formatRelativeTime(dateStr: string): string {
 
 export function AppSidebar() {
   const location = useLocation()
-  const navigate = useNavigate()
-  const { sessions, deleteSession, createSessionInProject } = useSessions()
+  const { sessions, deleteSession } = useSessions()
   const { data: projects = [] } = useProjectsList()
   const { createProject, addExistingProject, updateProject, removeProject } = useProjectMutations()
+  const { openNewDesign, openProjectComposer } = useNewDesignFlow({ projects })
 
   const pinnedProjects = useMemo(() => projects.filter((project) => project.pinned), [projects])
   const regularProjects = useMemo(() => projects.filter((project) => !project.pinned), [projects])
@@ -92,26 +92,21 @@ export function AppSidebar() {
   }, [sessions])
 
   const handleNewDesign = () => {
-    const project = getDefaultProject(projects)
-    if (project) {
-      navigate({ to: "/project/$projectId", params: { projectId: project.id } })
-    } else {
-      navigate({ to: "/" })
-    }
+    openNewDesign()
   }
 
   const handleStartFromScratch = async () => {
     const name = window.prompt("Project name")?.trim()
     if (!name) return
     const project = await createProject({ name })
-    navigate({ to: "/project/$projectId", params: { projectId: project.id } })
+    openProjectComposer(project.id)
   }
 
   const handleUseExistingFolder = async () => {
     const folder = await bridge.dialog.openDirectory()
     if (!folder) return
     const project = await addExistingProject({ path: folder })
-    navigate({ to: "/project/$projectId", params: { projectId: project.id } })
+    openProjectComposer(project.id)
   }
 
   const handleCollapseAll = () => {
@@ -120,30 +115,24 @@ export function AppSidebar() {
     })
   }
 
-  const handleStartNewChat = async (project: ProjectMeta) => {
-    const sessionId = await createSessionInProject(project)
-    if (!sessionId) return
-    navigate({
-      to: "/project/$projectId/session/$sessionId",
-      params: { projectId: project.id, sessionId },
-    })
+  const handleStartNewChat = (project: ProjectMeta) => {
+    openProjectComposer(project.id)
   }
 
   return (
     <Sidebar collapsible="offcanvas" variant="inset" className="group/sidebar-resizable">
-      <SidebarHeader className="h-[48px] pb-1 flex-row items-center justify-end px-3">
-        <SidebarTrigger
-          className="size-7 rounded-md text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground"
-          aria-label="Collapse sidebar"
-        />
-      </SidebarHeader>
+      <SidebarHeader className="h-[44px] flex-row items-center px-3 py-0" />
 
       <SidebarContent>
         <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu className="gap-1">
               <SidebarMenuItem>
-                <SidebarMenuButton className="h-8 text-[15px]" onClick={handleNewDesign} tooltip="New design">
+                <SidebarMenuButton
+                  className="h-8 text-[15px]"
+                  onClick={handleNewDesign}
+                  tooltip="New design"
+                >
                   <AddSquare size={17} />
                   <span>New design</span>
                 </SidebarMenuButton>
@@ -301,33 +290,36 @@ export function AppSidebar() {
 function SidebarResizeHandle() {
   const { state } = useSidebar()
 
-  const handlePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    if (state === "collapsed") return
-    event.preventDefault()
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (state === "collapsed") return
+      event.preventDefault()
 
-    const wrapper = event.currentTarget.closest<HTMLElement>('[data-slot="sidebar-wrapper"]')
-    if (!wrapper) return
+      const wrapper = event.currentTarget.closest<HTMLElement>('[data-slot="sidebar-wrapper"]')
+      if (!wrapper) return
 
-    const minWidth = 240
-    const maxWidth = 420
+      const minWidth = 240
+      const maxWidth = 420
 
-    const handlePointerMove = (moveEvent: PointerEvent) => {
-      const nextWidth = Math.min(maxWidth, Math.max(minWidth, moveEvent.clientX))
-      wrapper.style.setProperty("--sidebar-width", `${nextWidth}px`)
-    }
+      const handlePointerMove = (moveEvent: PointerEvent) => {
+        const nextWidth = Math.min(maxWidth, Math.max(minWidth, moveEvent.clientX))
+        wrapper.style.setProperty("--sidebar-width", `${nextWidth}px`)
+      }
 
-    const handlePointerUp = () => {
-      window.removeEventListener("pointermove", handlePointerMove)
-      window.removeEventListener("pointerup", handlePointerUp)
-      document.body.style.cursor = ""
-      document.body.style.userSelect = ""
-    }
+      const handlePointerUp = () => {
+        window.removeEventListener("pointermove", handlePointerMove)
+        window.removeEventListener("pointerup", handlePointerUp)
+        document.body.style.cursor = ""
+        document.body.style.userSelect = ""
+      }
 
-    document.body.style.cursor = "col-resize"
-    document.body.style.userSelect = "none"
-    window.addEventListener("pointermove", handlePointerMove)
-    window.addEventListener("pointerup", handlePointerUp, { once: true })
-  }, [state])
+      document.body.style.cursor = "col-resize"
+      document.body.style.userSelect = "none"
+      window.addEventListener("pointermove", handlePointerMove)
+      window.addEventListener("pointerup", handlePointerUp, { once: true })
+    },
+    [state],
+  )
 
   return (
     <div

--- a/apps/desktop/src/components/blocks/layout/page-header.tsx
+++ b/apps/desktop/src/components/blocks/layout/page-header.tsx
@@ -1,4 +1,8 @@
-import { SidebarTrigger, useSidebar } from "@dilag/ui/sidebar"
+import { AddSquare } from "@solar-icons/react"
+import { Button } from "@dilag/ui/button"
+import { useSidebar } from "@dilag/ui/sidebar"
+import { useNewDesignFlow } from "@/features/new-design/use-new-design-flow"
+import { useProjectsList } from "@/hooks/use-projects"
 import { cn } from "@/lib/utils"
 
 interface PageHeaderProps {
@@ -9,20 +13,28 @@ interface PageHeaderProps {
 export function PageHeader({ children, className }: PageHeaderProps) {
   const { state } = useSidebar()
   const isCollapsed = state === "collapsed"
+  const { data: projects = [] } = useProjectsList()
+  const { openNewDesign } = useNewDesignFlow({ projects })
 
   return (
     <header
       className={cn(
-        "h-[42px] pt-1 shrink-0 flex items-center gap-2 select-none border-b border-border pr-3",
-        isCollapsed ? "pl-[74px]" : "pl-3",
+        "h-[44px] shrink-0 flex items-center gap-1 select-none border-b border-border pr-3 transition-[padding] duration-150 ease-out",
+        isCollapsed ? "pl-(--titlebar-content-left)" : "pl-3",
         className,
       )}
     >
       {isCollapsed && (
-        <SidebarTrigger
-          className="-ml-1 size-7 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
-          aria-label="Open sidebar"
-        />
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-6 rounded-md text-muted-foreground hover:text-foreground"
+          onClick={openNewDesign}
+          aria-label="New design"
+          title="New design"
+        >
+          <AddSquare size={15} />
+        </Button>
       )}
       {children}
     </header>

--- a/apps/desktop/src/components/blocks/layout/persistent-sidebar-trigger.tsx
+++ b/apps/desktop/src/components/blocks/layout/persistent-sidebar-trigger.tsx
@@ -1,0 +1,20 @@
+import { SidebarTrigger, useSidebar } from "@dilag/ui/sidebar"
+import { cn } from "@/lib/utils"
+
+export function PersistentSidebarTrigger() {
+  const { state } = useSidebar()
+  const isCollapsed = state === "collapsed"
+
+  return (
+    <SidebarTrigger
+      className={cn(
+        "fixed left-(--titlebar-control-left) top-(--titlebar-control-center-y) z-50 size-(--titlebar-control-size) -translate-y-1/2 rounded-md border border-transparent text-muted-foreground/75 shadow-none transition-[background-color,color,border-color] duration-150 ease-out hover:bg-accent hover:text-foreground [&>svg]:size-3.5",
+        "focus-visible:ring-2 focus-visible:ring-ring/50",
+        isCollapsed
+          ? "bg-background/70 backdrop-blur supports-[backdrop-filter]:bg-background/55"
+          : "bg-sidebar/70 text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-foreground supports-[backdrop-filter]:bg-sidebar/55",
+      )}
+      aria-label="Toggle sidebar"
+    />
+  )
+}

--- a/apps/desktop/src/components/canvas/design-canvas.tsx
+++ b/apps/desktop/src/components/canvas/design-canvas.tsx
@@ -17,28 +17,20 @@ import { GhostScreenNode } from "./ghost-screen-node"
 import { CanvasControls } from "./canvas-controls"
 import type { DesignFile } from "@/hooks/use-designs"
 import type { ElementInfo } from "@/context/element-selection-store"
+import {
+  getGhostScreenPosition,
+  reconcileScreenPositions,
+  type ScreenPosition,
+} from "@/lib/screen-layout"
 import { cn } from "@/lib/utils"
+
+export type { ScreenPosition } from "@/lib/screen-layout"
 
 // Register custom node types
 const nodeTypes = {
   screen: ScreenNode,
   "ghost-screen": GhostScreenNode,
 }
-
-export interface ScreenPosition {
-  id: string
-  x: number
-  y: number
-}
-
-// Layout constants for ghost node positioning (must match studio route)
-const MOBILE_WIDTH = 280
-const MOBILE_HEIGHT = 584
-const WEB_WIDTH = 640
-const WEB_HEIGHT = 400
-const GAP = 60
-const MOBILE_COLUMNS = 4
-const WEB_COLUMNS = 2
 
 interface DesignCanvasProps {
   designs: DesignFile[]
@@ -72,23 +64,32 @@ function DesignCanvasInner({
 }: DesignCanvasProps) {
   const { getNodes } = useReactFlow()
 
-  // Convert ScreenPosition[] to React Flow nodes
+  // Convert designs and persisted ScreenPosition[] to React Flow nodes. The
+  // layout module reconciles missing persisted positions so available HTML
+  // screens still render while stored positions hydrate after reopening a session.
   const initialNodes = useMemo((): Node[] => {
-    const screenNodes = positions
-      .map((pos) => {
-        const design = designs.find((d) => d.filename === pos.id)
+    const renderablePositions = reconcileScreenPositions({
+      designs,
+      persistedPositions: positions,
+      platform,
+    })
+    const designById = new Map(designs.map((design) => [design.filename, design]))
+
+    const screenNodes = renderablePositions
+      .map((screenPosition) => {
+        const design = designById.get(screenPosition.id)
         if (!design) return null
 
         return {
-          id: pos.id,
+          id: screenPosition.id,
           type: "screen",
-          position: { x: pos.x, y: pos.y },
-          selected: selectedIds?.has(pos.id) ?? false,
+          position: { x: screenPosition.x, y: screenPosition.y },
+          selected: selectedIds?.has(screenPosition.id) ?? false,
           data: {
             design,
             platform,
             sessionCwd,
-            onDelete: onDeleteScreen ? () => onDeleteScreen(pos.id) : undefined,
+            onDelete: onDeleteScreen ? () => onDeleteScreen(screenPosition.id) : undefined,
             onAddToComposer: onCaptureScreen ? () => onCaptureScreen(design) : undefined,
             onEditElementWithAI: onEditElementWithAI
               ? (element: ElementInfo) => onEditElementWithAI(design, element)
@@ -96,31 +97,14 @@ function DesignCanvasInner({
           } as ScreenNodeData,
         } as Node
       })
-      .filter((n): n is Node => n !== null)
+      .filter((node): node is Node => node !== null)
 
-    // Add a ghost placeholder node when the AI is actively generating
+    // Add a ghost placeholder node when the AI is actively generating.
     if (isLoading) {
-      const isMobile = platform === "mobile"
-      const width = isMobile ? MOBILE_WIDTH : WEB_WIDTH
-      const height = isMobile ? MOBILE_HEIGHT : WEB_HEIGHT
-      const columns = isMobile ? MOBILE_COLUMNS : WEB_COLUMNS
-
-      const count = screenNodes.length
-      const col = count % columns
-      const row = Math.floor(count / columns)
-
-      // Find the start position from existing nodes, or use defaults
-      const startX =
-        screenNodes.length > 0 ? Math.min(...screenNodes.map((n) => n.position.x)) : 100
-      const startY = screenNodes.length > 0 ? Math.min(...screenNodes.map((n) => n.position.y)) : 40
-
       screenNodes.push({
         id: "__ghost__",
         type: "ghost-screen",
-        position: {
-          x: startX + col * (width + GAP),
-          y: startY + row * (height + GAP),
-        },
+        position: getGhostScreenPosition({ screenPositions: renderablePositions, platform }),
         selectable: false,
         draggable: false,
         data: { platform },
@@ -149,16 +133,18 @@ function DesignCanvasInner({
   const prevNodeKeyRef = useRef<string>("")
 
   useEffect(() => {
-    // Include modified_at timestamps to detect content changes, not just add/remove
+    // Include positions and modified_at timestamps to detect placement hydration,
+    // content changes, and add/remove changes.
     const nodeKey = initialNodes
       .map((n) => {
-        if (n.type === "ghost-screen") return `${n.id}:ghost`
-        return `${n.id}:${(n.data as ScreenNodeData).design.modified_at}`
+        const positionKey = `${n.position.x}:${n.position.y}`
+        if (n.type === "ghost-screen") return `${n.id}:ghost:${positionKey}`
+        return `${n.id}:${positionKey}:${(n.data as ScreenNodeData).design.modified_at}`
       })
       .sort()
       .join(",")
 
-    // Sync when nodes change (add/remove) OR when content changes (edit)
+    // Sync when nodes change (add/remove), positions hydrate, or content changes (edit).
     if (nodeKey !== prevNodeKeyRef.current) {
       prevNodeKeyRef.current = nodeKey
       isExternalSyncRef.current = true

--- a/apps/desktop/src/components/canvas/screen-node.tsx
+++ b/apps/desktop/src/components/canvas/screen-node.tsx
@@ -32,6 +32,7 @@ import {
 import { ElementHighlight } from "./element-highlight"
 import { ElementSelectionMenu } from "./element-selection-menu"
 import { getMobileViewportSize } from "@/lib/design-viewport"
+import { getCanonicalGeneratedScreenPath } from "@dilag/desktop-bridge"
 
 // Constants for frame sizes
 const WEB_WIDTH = 640
@@ -87,7 +88,9 @@ function ScreenNodeComponent({ id, data, selected }: NodeProps) {
     return injectInspector(withScrollbar)
   }, [design.html])
 
-  const filePath = design.file_path ?? (sessionCwd ? `${sessionCwd}/.designs/${design.filename}` : undefined)
+  const filePath =
+    design.file_path ??
+    (sessionCwd ? getCanonicalGeneratedScreenPath(sessionCwd, design.filename) : undefined)
 
   // Handle messages from iframe
   useEffect(() => {

--- a/apps/desktop/src/context/session-store.test.ts
+++ b/apps/desktop/src/context/session-store.test.ts
@@ -13,9 +13,12 @@ describe("session-store", () => {
       parts: {},
       sessionStatus: {},
       sessionDiffs: {},
+      promptQueues: {},
       isServerReady: false,
       error: null,
       debugEvents: [],
+      recentFileChanges: [],
+      designRefreshTick: 0,
     })
   })
 
@@ -294,6 +297,10 @@ describe("session-store", () => {
         ])
       useSessionStore.getState().setSessionStatus(sessionId, "running")
       useSessionStore.getState().setSessionDiffs(sessionId, [])
+      useSessionStore.getState().setPromptQueue(sessionId, {
+        steering: ["Check errors"],
+        followUp: ["Summarize next"],
+      })
 
       // Clear
       useSessionStore.getState().clearSessionData(sessionId)
@@ -302,6 +309,7 @@ describe("session-store", () => {
       expect(useSessionStore.getState().messages[sessionId]).toBeUndefined()
       expect(useSessionStore.getState().sessionStatus[sessionId]).toBeUndefined()
       expect(useSessionStore.getState().sessionDiffs[sessionId]).toBeUndefined()
+      expect(useSessionStore.getState().promptQueues[sessionId]).toBeUndefined()
     })
   })
 
@@ -404,6 +412,28 @@ describe("session-store", () => {
       expect(useSessionStore.getState().sessionStatus["session-1"]).toBe("running")
     })
 
+    it("should replace queued follow-up state from prompt queue events", () => {
+      const sessionId = "session-1"
+      useSessionStore.getState().setPromptQueue(sessionId, {
+        steering: ["old steering"],
+        followUp: ["old follow-up"],
+      })
+
+      useSessionStore.getState().handleEvent({
+        type: "prompt.queue.updated",
+        properties: {
+          sessionID: sessionId,
+          steering: ["Focus on errors"],
+          followUp: ["After that, make it dark"],
+        },
+      } as any)
+
+      expect(useSessionStore.getState().promptQueues[sessionId]).toEqual({
+        steering: ["Focus on errors"],
+        followUp: ["After that, make it dark"],
+      })
+    })
+
     it("should stop streaming assistant messages when session becomes idle", () => {
       const sessionId = "session-1"
       useSessionStore.getState().setMessages(sessionId, [
@@ -478,6 +508,29 @@ describe("session-store", () => {
       expect(useSessionStore.getState().recentFileChanges).toMatchObject([
         { file: ".designs/home.html", event: "change" },
       ])
+    })
+
+    it("bumps design refresh when write tools complete", () => {
+      useSessionStore.getState().updatePart("msg-1", {
+        id: "tool-1",
+        messageID: "msg-1",
+        sessionID: "session-1",
+        type: "tool",
+        tool: "write",
+        state: { status: "running", input: { filePath: ".designs/home.html" } },
+      })
+      expect(useSessionStore.getState().designRefreshTick).toBe(0)
+
+      useSessionStore.getState().updatePart("msg-1", {
+        id: "tool-1",
+        messageID: "msg-1",
+        sessionID: "session-1",
+        type: "tool",
+        tool: "write",
+        state: { status: "completed", input: { filePath: ".designs/home.html" } },
+      })
+
+      expect(useSessionStore.getState().designRefreshTick).toBe(1)
     })
   })
 })

--- a/apps/desktop/src/context/session-store.tsx
+++ b/apps/desktop/src/context/session-store.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react"
 import { create } from "zustand"
 import { persist, createJSONStorage } from "zustand/middleware"
 import { immer } from "zustand/middleware/immer"
+import type { ScreenPosition } from "@/lib/screen-layout"
 import {
   isEventMessagePartUpdated,
   isEventMessageUpdated,
@@ -20,8 +21,10 @@ import {
   isEventQuestionAsked,
   isEventQuestionReplied,
   isEventQuestionRejected,
+  isEventPromptQueueUpdated,
   type PermissionRequest,
   type QuestionRequest,
+  type PromptQueueState,
   type EventQuestionAsked,
   type EventQuestionReplied,
   type EventQuestionRejected,
@@ -37,9 +40,10 @@ export type {
   QuestionInfo,
   QuestionOption,
 } from "@/lib/event-guards"
+export type { ScreenPosition } from "@/lib/screen-layout"
 
 // Re-export SDK types
-export type { ToolState, FileDiff }
+export type { ToolState, FileDiff, PromptQueueState }
 
 // Our internal session status type (simpler than SDK's object type)
 export type SessionStatus = "idle" | "running" | "busy" | "error" | "unknown"
@@ -131,13 +135,6 @@ export interface DesignScreen {
   createdAt: number
 }
 
-// Screen position for canvas
-export interface ScreenPosition {
-  id: string
-  x: number
-  y: number
-}
-
 /**
  * Session Store - Zustand store for CLIENT-ONLY and REAL-TIME state
  *
@@ -159,6 +156,7 @@ interface SessionState {
   sessionDiffs: Record<string, FileDiff[]> // Keyed by sessionId
   sessionErrors: Record<string, { name: string; message: string } | null> // Keyed by sessionId
   sessionRevert: Record<string, SessionRevertState | null> // Keyed by sessionId - tracks revert state
+  promptQueues: Record<string, PromptQueueState> // Keyed by sessionId
 
   // New event state
   serverHealth: ServerHealth
@@ -189,6 +187,7 @@ interface SessionState {
   setSessionDiffs: (sessionId: string, diffs: FileDiff[]) => void
   setSessionError: (sessionId: string, error: { name: string; message: string } | null) => void
   setSessionRevert: (sessionId: string, revert: SessionRevertState | null) => void
+  setPromptQueue: (sessionId: string, queue: PromptQueueState) => void
   removeMessage: (sessionId: string, messageId: string) => void
   removeMessagesAfter: (sessionId: string, messageId: string) => void
   clearSessionData: (sessionId: string) => void
@@ -276,6 +275,16 @@ function shouldKeepExistingPart(existing: MessagePart, incoming: MessagePart): b
   return isTerminalToolStatus(existingStatus) && !isTerminalToolStatus(incomingStatus)
 }
 
+function shouldRefreshDesignsForToolPart(
+  existing: MessagePart | undefined,
+  incoming: MessagePart,
+): boolean {
+  if (incoming.type !== "tool") return false
+  if (incoming.tool !== "write" && incoming.tool !== "edit") return false
+  if (incoming.state?.status !== "completed") return false
+  return existing?.state?.status !== "completed"
+}
+
 export const useSessionStore = create<SessionState>()(
   persist(
     immer((set, get) => ({
@@ -288,6 +297,7 @@ export const useSessionStore = create<SessionState>()(
       sessionDiffs: {},
       sessionErrors: {},
       sessionRevert: {},
+      promptQueues: {},
       serverHealth: { lastHeartbeat: 0, isHealthy: false },
       pendingPermissions: {},
       pendingQuestions: {},
@@ -344,15 +354,25 @@ export const useSessionStore = create<SessionState>()(
           const parts = state.parts[messageId]
           if (!parts) {
             state.parts[messageId] = [part]
+            if (shouldRefreshDesignsForToolPart(undefined, part)) {
+              state.designRefreshTick += 1
+            }
             return
           }
 
           const result = binarySearch(parts, part.id, (p) => p.id)
           if (result.found) {
-            if (shouldKeepExistingPart(parts[result.index], part)) return
+            const existing = parts[result.index]
+            if (shouldKeepExistingPart(existing, part)) return
             parts[result.index] = part
+            if (shouldRefreshDesignsForToolPart(existing, part)) {
+              state.designRefreshTick += 1
+            }
           } else {
             parts.splice(result.index, 0, part)
+            if (shouldRefreshDesignsForToolPart(undefined, part)) {
+              state.designRefreshTick += 1
+            }
           }
         }),
 
@@ -374,6 +394,14 @@ export const useSessionStore = create<SessionState>()(
       setSessionRevert: (sessionId, revert) =>
         set((state) => {
           state.sessionRevert[sessionId] = revert
+        }),
+
+      setPromptQueue: (sessionId, queue) =>
+        set((state) => {
+          state.promptQueues[sessionId] = {
+            steering: [...queue.steering],
+            followUp: [...queue.followUp],
+          }
         }),
 
       removeMessage: (sessionId, messageId) =>
@@ -412,6 +440,7 @@ export const useSessionStore = create<SessionState>()(
           delete state.sessionDiffs[sessionId]
           delete state.sessionErrors[sessionId]
           delete state.sessionRevert[sessionId]
+          delete state.promptQueues[sessionId]
           delete state.pendingPermissions[sessionId]
           delete state.pendingQuestions[sessionId]
           if (state.currentSessionId === sessionId) {
@@ -600,6 +629,7 @@ export const useSessionStore = create<SessionState>()(
           state.sessionDiffs = {}
           state.sessionErrors = {}
           state.sessionRevert = {}
+          state.promptQueues = {}
           state.pendingPermissions = {}
           state.pendingQuestions = {}
           state.serverHealth = { lastHeartbeat: 0, isHealthy: false }
@@ -622,6 +652,7 @@ export const useSessionStore = create<SessionState>()(
           setSessionDiffs,
           setSessionError,
           setSessionRevert,
+          setPromptQueue,
           removeMessage,
           setServerHealth,
           addPendingPermission,
@@ -636,6 +667,12 @@ export const useSessionStore = create<SessionState>()(
         addDebugEvent(event)
 
         // Use type guards for type-safe event handling
+        if (isEventPromptQueueUpdated(event)) {
+          const { sessionID, steering, followUp } = event.properties
+          setPromptQueue(sessionID, { steering, followUp })
+          return
+        }
+
         if (isEventMessagePartUpdated(event)) {
           const sdkPart = event.properties.part
           if (sdkPart.messageID) {
@@ -837,6 +874,8 @@ const EMPTY_MESSAGES: Message[] = []
 const EMPTY_PARTS: MessagePart[] = []
 const EMPTY_DIFFS: FileDiff[] = []
 const EMPTY_POSITIONS: ScreenPosition[] = []
+const EMPTY_PROMPT_QUEUE: PromptQueueState = { steering: [], followUp: [] }
+const EMPTY_PROMPT_QUEUE_MESSAGES: string[] = []
 
 // Selector hooks for Zustand state
 export const useCurrentSessionId = () => useSessionStore((state) => state.currentSessionId)
@@ -867,6 +906,16 @@ export const useResetRealtimeState = () => useSessionStore((state) => state.rese
 export const useAllSessionStatuses = () => useSessionStore((state) => state.sessionStatus)
 export const useSessionRevert = (sessionId: string | null) =>
   useSessionStore((state) => (sessionId ? (state.sessionRevert[sessionId] ?? null) : null))
+export const usePromptQueue = (sessionId: string | null) =>
+  useSessionStore((state) =>
+    sessionId ? (state.promptQueues[sessionId] ?? EMPTY_PROMPT_QUEUE) : EMPTY_PROMPT_QUEUE,
+  )
+export const useQueuedFollowUps = (sessionId: string | null) =>
+  useSessionStore((state) =>
+    sessionId
+      ? (state.promptQueues[sessionId]?.followUp ?? EMPTY_PROMPT_QUEUE_MESSAGES)
+      : EMPTY_PROMPT_QUEUE_MESSAGES,
+  )
 
 // New event state selectors
 const EMPTY_PERMISSIONS: PermissionRequest[] = []

--- a/apps/desktop/src/features/new-design/use-new-design-flow.test.ts
+++ b/apps/desktop/src/features/new-design/use-new-design-flow.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest"
+import type { ProjectMeta } from "@dilag/desktop-bridge"
+import type { FileUIPart } from "ai"
+import {
+  createNewDesignFlow,
+  NEW_DESIGN_STORAGE_KEYS,
+  type NewDesignNavigation,
+  type NewDesignStorage,
+} from "./use-new-design-flow"
+
+function project(overrides: Partial<ProjectMeta>): ProjectMeta {
+  return {
+    id: "project-1",
+    name: "Checkout",
+    path: "/projects/checkout",
+    platform: "web",
+    pinned: false,
+    expanded: true,
+    created_at: "2026-05-15T00:00:00.000Z",
+    last_opened_at: "2026-05-15T00:00:00.000Z",
+    ...overrides,
+  }
+}
+
+function createStorage(): NewDesignStorage & { values: Map<string, string> } {
+  const values = new Map<string, string>()
+  return {
+    values,
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value)
+    }),
+    removeItem: vi.fn((key: string) => {
+      values.delete(key)
+    }),
+  }
+}
+
+function createNavigation(): NewDesignNavigation {
+  return {
+    openHome: vi.fn(),
+    openProjectComposer: vi.fn(),
+    openProjectStudio: vi.fn(),
+  }
+}
+
+describe("new design flow", () => {
+  it("opens New design at the default project composer without creating a Pi session", () => {
+    const storage = createStorage()
+    const navigation = createNavigation()
+    const touchProject = vi.fn()
+    const createSessionInProject = vi.fn()
+    const projects = [
+      project({ id: "recent", pinned: false, last_opened_at: "2026-05-16T00:00:00.000Z" }),
+      project({ id: "pinned", pinned: true, last_opened_at: "2026-05-15T00:00:00.000Z" }),
+    ]
+
+    const flow = createNewDesignFlow({
+      projects,
+      navigation,
+      storage,
+      touchProject,
+      createSessionInProject,
+    })
+
+    flow.openNewDesign()
+
+    expect(navigation.openProjectComposer).toHaveBeenCalledWith("pinned")
+    expect(storage.values.get(NEW_DESIGN_STORAGE_KEYS.lastProjectId)).toBe("pinned")
+    expect(touchProject).not.toHaveBeenCalled()
+    expect(createSessionInProject).not.toHaveBeenCalled()
+  })
+
+  it("opens New design at Home when no project exists", () => {
+    const navigation = createNavigation()
+    const flow = createNewDesignFlow({
+      projects: [],
+      navigation,
+      storage: createStorage(),
+      touchProject: vi.fn(),
+      createSessionInProject: vi.fn(),
+    })
+
+    flow.openNewDesign()
+
+    expect(navigation.openHome).toHaveBeenCalled()
+    expect(navigation.openProjectComposer).not.toHaveBeenCalled()
+  })
+
+  it("opens a project composer without creating a Pi session", () => {
+    const storage = createStorage()
+    const navigation = createNavigation()
+    const touchProject = vi.fn()
+    const createSessionInProject = vi.fn()
+    const flow = createNewDesignFlow({
+      projects: [],
+      navigation,
+      storage,
+      touchProject,
+      createSessionInProject,
+    })
+
+    flow.openProjectComposer("project-42")
+
+    expect(navigation.openProjectComposer).toHaveBeenCalledWith("project-42")
+    expect(storage.values.get(NEW_DESIGN_STORAGE_KEYS.lastProjectId)).toBe("project-42")
+    expect(touchProject).not.toHaveBeenCalled()
+    expect(createSessionInProject).not.toHaveBeenCalled()
+  })
+
+  it("creates and opens a Pi session only when the composer prompt is submitted", async () => {
+    const checkoutProject = project({ id: "checkout", platform: "mobile", pinned: true })
+    const files: FileUIPart[] = [
+      {
+        type: "file",
+        mediaType: "image/png",
+        filename: "reference.png",
+        url: "data:image/png;base64,abc",
+      },
+    ]
+    const storage = createStorage()
+    const navigation = createNavigation()
+    const touchProject = vi.fn().mockResolvedValue(checkoutProject)
+    const createSessionInProject = vi.fn().mockResolvedValue("session-1")
+    const flow = createNewDesignFlow({
+      projects: [checkoutProject],
+      navigation,
+      storage,
+      touchProject,
+      createSessionInProject,
+    })
+
+    await expect(
+      flow.submitProjectComposer(checkoutProject, "Build checkout", files),
+    ).resolves.toBe("session-1")
+
+    expect(storage.values.get(NEW_DESIGN_STORAGE_KEYS.initialPrompt)).toBe("Build checkout")
+    expect(storage.values.get(NEW_DESIGN_STORAGE_KEYS.initialPlatform)).toBe("mobile")
+    expect(storage.values.get(NEW_DESIGN_STORAGE_KEYS.initialFiles)).toBe(JSON.stringify(files))
+    expect(touchProject).toHaveBeenCalledWith("checkout")
+    expect(createSessionInProject).toHaveBeenCalledWith(checkoutProject)
+    expect(navigation.openProjectStudio).toHaveBeenCalledWith("checkout", "session-1")
+  })
+
+  it("ignores empty composer submissions", async () => {
+    const checkoutProject = project({ id: "checkout" })
+    const navigation = createNavigation()
+    const touchProject = vi.fn()
+    const createSessionInProject = vi.fn()
+    const flow = createNewDesignFlow({
+      projects: [checkoutProject],
+      navigation,
+      storage: createStorage(),
+      touchProject,
+      createSessionInProject,
+    })
+
+    await expect(flow.submitProjectComposer(checkoutProject, "   ")).resolves.toBeNull()
+
+    expect(touchProject).not.toHaveBeenCalled()
+    expect(createSessionInProject).not.toHaveBeenCalled()
+    expect(navigation.openProjectStudio).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/features/new-design/use-new-design-flow.ts
+++ b/apps/desktop/src/features/new-design/use-new-design-flow.ts
@@ -1,0 +1,144 @@
+import { useMemo } from "react"
+import { useNavigate } from "@tanstack/react-router"
+import type { ProjectMeta } from "@dilag/desktop-bridge"
+import type { FileUIPart } from "ai"
+import { getDefaultProject } from "@/hooks/use-projects"
+
+export const NEW_DESIGN_STORAGE_KEYS = {
+  lastProjectId: "dilag-last-project-id",
+  initialPrompt: "dilag-initial-prompt",
+  initialPlatform: "dilag-initial-platform",
+  initialFiles: "dilag-initial-files",
+} as const
+
+export interface NewDesignStorage {
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+export interface NewDesignNavigation {
+  openHome(): void
+  openProjectComposer(projectId: string): void
+  openProjectStudio(projectId: string, sessionId: string): void
+}
+
+export interface NewDesignFlowDependencies {
+  projects: ProjectMeta[]
+  navigation: NewDesignNavigation
+  storage: NewDesignStorage
+  touchProject: (projectId: string) => Promise<unknown>
+  createSessionInProject: (project: ProjectMeta) => Promise<string | null>
+}
+
+export interface NewDesignFlow {
+  openNewDesign(): void
+  openProjectComposer(projectId: string): void
+  rememberProject(projectId: string): void
+  submitProjectComposer(
+    project: ProjectMeta,
+    prompt: string,
+    files?: FileUIPart[],
+  ): Promise<string | null>
+}
+
+export function createNewDesignFlow({
+  projects,
+  navigation,
+  storage,
+  touchProject,
+  createSessionInProject,
+}: NewDesignFlowDependencies): NewDesignFlow {
+  const rememberProject = (projectId: string) => {
+    storage.setItem(NEW_DESIGN_STORAGE_KEYS.lastProjectId, projectId)
+  }
+
+  const openProjectComposer = (projectId: string) => {
+    rememberProject(projectId)
+    navigation.openProjectComposer(projectId)
+  }
+
+  const openNewDesign = () => {
+    const project = getDefaultProject(projects)
+    if (!project) {
+      navigation.openHome()
+      return
+    }
+
+    openProjectComposer(project.id)
+  }
+
+  const submitProjectComposer = async (
+    project: ProjectMeta,
+    prompt: string,
+    files?: FileUIPart[],
+  ): Promise<string | null> => {
+    if (!prompt.trim() && (!files || files.length === 0)) return null
+
+    storage.setItem(NEW_DESIGN_STORAGE_KEYS.initialPrompt, prompt)
+    storage.setItem(NEW_DESIGN_STORAGE_KEYS.initialPlatform, project.platform)
+    if (files && files.length > 0) {
+      storage.setItem(NEW_DESIGN_STORAGE_KEYS.initialFiles, JSON.stringify(files))
+    } else {
+      storage.removeItem(NEW_DESIGN_STORAGE_KEYS.initialFiles)
+    }
+
+    rememberProject(project.id)
+    await touchProject(project.id)
+
+    const sessionId = await createSessionInProject(project)
+    if (!sessionId) return null
+
+    navigation.openProjectStudio(project.id, sessionId)
+    return sessionId
+  }
+
+  return {
+    openNewDesign,
+    openProjectComposer,
+    rememberProject,
+    submitProjectComposer,
+  }
+}
+
+export interface UseNewDesignFlowDependencies {
+  projects: ProjectMeta[]
+  touchProject?: NewDesignFlowDependencies["touchProject"]
+  createSessionInProject?: NewDesignFlowDependencies["createSessionInProject"]
+}
+
+export function useNewDesignFlow({
+  projects,
+  touchProject,
+  createSessionInProject,
+}: UseNewDesignFlowDependencies): NewDesignFlow {
+  const navigate = useNavigate()
+
+  return useMemo(
+    () =>
+      createNewDesignFlow({
+        projects,
+        touchProject:
+          touchProject ??
+          (async () => {
+            throw new Error("Cannot submit a project composer without a project mutation adapter")
+          }),
+        createSessionInProject:
+          createSessionInProject ??
+          (async () => {
+            throw new Error("Cannot submit a project composer without a session adapter")
+          }),
+        storage: window.localStorage,
+        navigation: {
+          openHome: () => navigate({ to: "/" }),
+          openProjectComposer: (projectId) =>
+            navigate({ to: "/project/$projectId", params: { projectId } }),
+          openProjectStudio: (projectId, sessionId) =>
+            navigate({
+              to: "/project/$projectId/session/$sessionId",
+              params: { projectId, sessionId },
+            }),
+        },
+      }),
+    [projects, touchProject, createSessionInProject, navigate],
+  )
+}

--- a/apps/desktop/src/hooks/use-designs.test.ts
+++ b/apps/desktop/src/hooks/use-designs.test.ts
@@ -150,10 +150,16 @@ describe("isSessionDesignFileChange", () => {
     expect(isSessionDesignFileChange(".designs/home.html", "/sessions/abc")).toBe(true)
   })
 
-  it("ignores root, screens, non-html, and nested non-design files", () => {
+  it("matches legacy screens html files as displayable designs", () => {
+    expect(isSessionDesignFileChange("/sessions/abc/screens/home.html", "/sessions/abc")).toBe(true)
+    expect(isSessionDesignFileChange("screens/home.html", "/sessions/abc")).toBe(true)
+  })
+
+  it("ignores root, non-html, and nested non-design files", () => {
     expect(isSessionDesignFileChange("/sessions/abc/home.html", "/sessions/abc")).toBe(false)
-    expect(isSessionDesignFileChange("/sessions/abc/screens/home.html", "/sessions/abc")).toBe(false)
-    expect(isSessionDesignFileChange("/sessions/abc/.designs/home.png", "/sessions/abc")).toBe(false)
+    expect(isSessionDesignFileChange("/sessions/abc/.designs/home.png", "/sessions/abc")).toBe(
+      false,
+    )
     expect(isSessionDesignFileChange("/sessions/abc/src/home.html", "/sessions/abc")).toBe(false)
   })
 })

--- a/apps/desktop/src/hooks/use-designs.ts
+++ b/apps/desktop/src/hooks/use-designs.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { bridge } from "@/lib/bridge"
 import { useSessionStore } from "@/context/session-store"
+import { isGeneratedScreenFile } from "@dilag/desktop-bridge"
 
 export type ViolationRule =
   | "keyframes"
@@ -30,21 +31,8 @@ async function loadSessionDesigns(sessionCwd: string): Promise<DesignFile[]> {
   return bridge.designs.loadForSession({ sessionCwd })
 }
 
-function normalizePath(path: string): string {
-  return path.replace(/\\/g, "/").replace(/\/$/, "")
-}
-
 export function isSessionDesignFileChange(file: string, sessionCwd: string): boolean {
-  const normalizedFile = normalizePath(file)
-  const normalizedCwd = normalizePath(sessionCwd)
-  const relativePath = normalizedFile.startsWith(normalizedCwd + "/")
-    ? normalizedFile.slice(normalizedCwd.length + 1)
-    : normalizedFile
-
-  return (
-    relativePath.endsWith(".html") &&
-    relativePath.startsWith(".designs/")
-  )
+  return isGeneratedScreenFile(file, sessionCwd)
 }
 
 /**

--- a/apps/desktop/src/hooks/use-png-generator.ts
+++ b/apps/desktop/src/hooks/use-png-generator.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react"
 import { bridge } from "@/lib/bridge"
 import { generatePngToPath } from "@/lib/design-export"
 import type { DesignFile } from "./use-designs"
+import { getCanonicalGeneratedScreenPath } from "@dilag/desktop-bridge"
 
 /**
  * Auto-generates PNG assets for designs when HTML is newer than PNG
@@ -22,7 +23,9 @@ export function usePngGenerator(
 
     const generate = async (design: DesignFile) => {
       const basePath = design.file_path?.replace(/\.html$/, ".png")
-      const pngPath = basePath ?? `${sessionCwd}/.designs/${design.filename.replace(".html", ".png")}`
+      const pngPath =
+        basePath ??
+        getCanonicalGeneratedScreenPath(sessionCwd, design.filename.replace(".html", ".png"))
 
       // Skip if already generating (mark immediately to prevent race condition)
       if (generating.current.has(pngPath)) return

--- a/apps/desktop/src/hooks/use-sessions.test.ts
+++ b/apps/desktop/src/hooks/use-sessions.test.ts
@@ -103,6 +103,7 @@ describe("use-sessions", () => {
       sessionDiffs: {},
       sessionRevert: {},
       sessionErrors: {},
+      promptQueues: {},
       isServerReady: true,
       error: null,
       debugEvents: [],
@@ -248,6 +249,26 @@ describe("use-sessions", () => {
       })
 
       expect(useSessionStore.getState().sessionStatus["session-1"]).toBe("running")
+    })
+
+    it("queues follow-up prompts through Pi while a session is running", async () => {
+      useSessionStore.setState({ sessionStatus: { "session-1": "running" } })
+      const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
+
+      await act(async () => {
+        await expect(result.current.sendMessage("Also make it dark")).resolves.toEqual({
+          mode: "followUp",
+          status: "queued",
+        })
+      })
+
+      expect(mockPrompt).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionID: "session-1",
+          text: "/skill:dilag-web-design Also make it dark",
+          streamingBehavior: "followUp",
+        }),
+      )
     })
 
     it("handles prompt errors gracefully", async () => {

--- a/apps/desktop/src/hooks/use-sessions.ts
+++ b/apps/desktop/src/hooks/use-sessions.ts
@@ -23,13 +23,9 @@ import { useModelStore } from "@/hooks/use-models"
 import { useAgentStore } from "@/hooks/use-agents"
 import { withErrorHandler } from "@/lib/async-utils"
 import { bridge } from "@/lib/bridge"
-import type {
-  AgentImageContent as BridgeAgentImageContent,
-  AgentMessage as BridgeAgentMessage,
-  ProjectMeta,
-} from "@dilag/desktop-bridge"
+import type { AgentMessage as BridgeAgentMessage, ProjectMeta } from "@dilag/desktop-bridge"
 import type { FileUIPart } from "ai"
-import { formatElementWithAncestry, minifyHtml } from "@/lib/html-utils"
+import { deliverDilagPrompt } from "@/lib/prompt-delivery"
 
 // Convert bridge message parts to our internal format.
 function convertPart(
@@ -578,121 +574,28 @@ export function useSessions() {
         )
         console.log("[sendMessage] directory:", directory)
 
-        // On first message, prepend skill instruction
-        const platform = currentSession.platform ?? "web"
-        const isFirstMessage = messages.length === 0
-        const skillHint = isFirstMessage ? `/skill:dilag-${platform}-design ` : ""
-
-        let promptText = skillHint + content
-
-        // HTML screen references: prepend @ScreenName inline, append HTML context at end
-        const screenContexts: string[] = []
-        const screenNames: string[] = []
-        const fileNotes: string[] = []
-        const images: BridgeAgentImageContent[] = []
-
-        if (files && files.length > 0) {
-          for (const file of files) {
-            if (file.url) {
-              // HTML files: collect for inline @name prefix and hidden context block
-              if (file.mediaType === "text/html") {
-                const base64Match = file.url.match(/^data:text\/html;base64,(.+)$/)
-                if (base64Match) {
-                  try {
-                    let htmlContent = decodeURIComponent(escape(atob(base64Match[1])))
-                    const screenName = file.filename?.replace(".html", "") || "Screen"
-
-                    // Check for element selection marker
-                    const elementMarkerMatch = htmlContent.match(
-                      /<!-- dilag-element-selection: ({.*?}) -->/,
-                    )
-                    let elementInfo: {
-                      selector: string
-                      html: string
-                      tagName: string
-                      ancestorPath?: string[]
-                    } | null = null
-
-                    if (elementMarkerMatch) {
-                      try {
-                        elementInfo = JSON.parse(elementMarkerMatch[1])
-                        // Remove the marker from the HTML content
-                        htmlContent = htmlContent.replace(elementMarkerMatch[0], "").trim()
-                      } catch (e) {
-                        console.error("[sendMessage] Failed to parse element selection marker:", e)
-                      }
-                    }
-
-                    // Format with or without element context
-                    if (elementInfo) {
-                      // For element editing: compact format only, no full HTML
-                      // AI can read the screen file if it needs full context
-                      const compactElement = formatElementWithAncestry(
-                        elementInfo.html,
-                        elementInfo.ancestorPath,
-                      )
-                      screenNames.push(`${screenName} (${elementInfo.tagName})`)
-                      screenContexts.push(
-                        `<edit_element screen="${screenName}" selector="${elementInfo.selector}">\n` +
-                          `${compactElement}\n` +
-                          `</edit_element>`,
-                      )
-                    } else {
-                      // For full screen reference: minify HTML
-                      const minifiedHtml = minifyHtml(htmlContent)
-                      screenNames.push(screenName)
-                      screenContexts.push(
-                        `<screen_context name="${screenName}">${minifiedHtml}</screen_context>`,
-                      )
-                    }
-                  } catch (e) {
-                    console.error("[sendMessage] Failed to decode HTML content:", e)
-                  }
-                }
-              } else if (file.mediaType?.startsWith("image/")) {
-                const dataUrlMatch = file.url.match(/^data:([^;,]+);base64,(.+)$/)
-                if (dataUrlMatch) {
-                  images.push({
-                    type: "image",
-                    mimeType: dataUrlMatch[1] || file.mediaType,
-                    data: dataUrlMatch[2],
-                  })
-                } else if (file.filename) {
-                  fileNotes.push(`Attached image not inlined: ${file.filename}`)
-                }
-              } else if (file.filename) {
-                fileNotes.push(`Attached file not inlined: ${file.filename}`)
-              }
-            }
-          }
-        }
-
-        // Update the text part with inline @names and append screen context
-        if (screenNames.length > 0) {
-          const inlineRefs = screenNames.map((name) => `@${name}`).join(" ")
-          const contextBlock = screenContexts.join("\n\n")
-          promptText = `${skillHint}${inlineRefs} ${content}\n\n${contextBlock}`
-        }
-
-        if (fileNotes.length > 0) {
-          promptText += `\n\n${fileNotes.join("\n")}`
-        }
-
         console.log("[sendMessage] calling bridge.agent.prompt with:", {
           sessionID: currentSessionId,
           agent: agentName,
           model: selectedModel,
           thinkingLevel: selectedThinkingLevel,
         })
-        await bridge.agent.prompt({
-          sessionID: currentSessionId,
-          directory,
-          text: promptText,
-          images,
+        const delivery = await deliverDilagPrompt({
+          session: {
+            id: currentSessionId,
+            cwd: directory,
+            platform: currentSession.platform ?? "web",
+          },
+          content,
+          files,
+          isFirstMessage: messages.length === 0,
+          sessionStatus,
+          hasRunningTools,
           model: selectedModel,
           thinkingLevel: selectedThinkingLevel,
         })
-        console.log("[sendMessage] prompt accepted")
+        console.log("[sendMessage] prompt accepted", delivery)
+        return delivery
       } catch (err) {
         if (!isMountedRef.current) return
         setError(err instanceof Error ? err.message : "Failed to send message")
@@ -701,7 +604,16 @@ export function useSessions() {
         throw err
       }
     },
-    [currentSessionId, currentSession, messages, setError, setSessionStatus, setSessionError],
+    [
+      currentSessionId,
+      currentSession,
+      messages,
+      sessionStatus,
+      hasRunningTools,
+      setError,
+      setSessionStatus,
+      setSessionError,
+    ],
   )
 
   const toggleFavorite = useCallback(

--- a/apps/desktop/src/lib/design-skill-pack.test.ts
+++ b/apps/desktop/src/lib/design-skill-pack.test.ts
@@ -1,0 +1,62 @@
+import fsp from "node:fs/promises"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+import {
+  DILAG_MOBILE_DESIGN_SKILL_NAME,
+  DILAG_WEB_DESIGN_SKILL_NAME,
+  renderDesignSkill,
+  type DilagDesignSkillAssets,
+} from "../../electron/ipc/design-skill-pack"
+
+async function loadAssets(): Promise<DilagDesignSkillAssets> {
+  const assetDir = path.resolve(process.cwd(), "resources", "design-assets")
+  const [commonTemplate, htmlScreenContractTemplate, mobileTemplate, webTemplate] =
+    await Promise.all([
+      fsp.readFile(path.join(assetDir, "designer-common.md"), "utf8"),
+      fsp.readFile(path.join(assetDir, "html-screen-contract.md"), "utf8"),
+      fsp.readFile(path.join(assetDir, "mobile-designer-prompt.md"), "utf8"),
+      fsp.readFile(path.join(assetDir, "web-designer-prompt.md"), "utf8"),
+    ])
+
+  return {
+    commonTemplate,
+    htmlScreenContractTemplate,
+    mobileTemplate,
+    webTemplate,
+  }
+}
+
+describe("design skill pack", () => {
+  it("renders the mobile skill with the HTML screen contract and Dilag skill name", async () => {
+    const skill = renderDesignSkill("mobile", await loadAssets(), {})
+
+    expect(skill).toContain(`name: ${DILAG_MOBILE_DESIGN_SKILL_NAME}`)
+    expect(skill).toContain("## HTML Screen Contract")
+    expect(skill).toContain("`.designs/<kebab-name>.html`")
+    expect(skill).toContain("`screens/` is deprecated fallback for display only")
+    expect(skill).toContain('data-screen-type="mobile"')
+    expect(skill).not.toContain("{{GENERATED_SCREEN_OUTPUT_RULES}}")
+    expect(skill).not.toContain("{{HTML_SCREEN_CONTRACT}}")
+  })
+
+  it("renders the web skill with the HTML screen contract and Dilag skill name", async () => {
+    const skill = renderDesignSkill("web", await loadAssets(), {})
+
+    expect(skill).toContain(`name: ${DILAG_WEB_DESIGN_SKILL_NAME}`)
+    expect(skill).toContain("## HTML Screen Contract")
+    expect(skill).toContain("`.designs/<kebab-name>.html`")
+    expect(skill).toContain('data-screen-type="web"')
+  })
+
+  it("uses environment fallback text when optional hints are absent", async () => {
+    const skill = renderDesignSkill("web", await loadAssets(), {
+      DILAG_BRAND_TOKENS: " ",
+      DILAG_DOMAIN_HINT: undefined,
+      DILAG_REFERENCE_URLS: "",
+    })
+
+    expect(
+      skill.match(/\(none specified - use your judgment based on the user's request\)/g),
+    ).toHaveLength(3)
+  })
+})

--- a/apps/desktop/src/lib/event-guards.ts
+++ b/apps/desktop/src/lib/event-guards.ts
@@ -3,6 +3,8 @@
  * The Electron Pi adapter emits this stable event envelope for the renderer.
  */
 
+import type { AgentPromptQueueState } from "@dilag/desktop-bridge"
+
 export type ToolStateStatus = "pending" | "running" | "completed" | "error"
 
 export interface ToolState {
@@ -41,6 +43,13 @@ export interface Part {
 export interface Event {
   type: string
   properties?: unknown
+}
+
+export type PromptQueueState = Omit<AgentPromptQueueState, "sessionID">
+
+export interface EventPromptQueueUpdated extends Event {
+  type: "prompt.queue.updated"
+  properties: AgentPromptQueueState
 }
 
 export interface EventMessagePartUpdated extends Event {
@@ -227,6 +236,23 @@ export interface EventQuestionRejected {
     sessionID: string
     requestID: string
   }
+}
+
+/**
+ * Type guard for prompt.queue.updated events
+ */
+export function isEventPromptQueueUpdated(event: Event): event is EventPromptQueueUpdated {
+  return (
+    event.type === "prompt.queue.updated" &&
+    "properties" in event &&
+    event.properties !== null &&
+    typeof event.properties === "object" &&
+    "sessionID" in event.properties &&
+    "steering" in event.properties &&
+    "followUp" in event.properties &&
+    Array.isArray((event.properties as Record<string, unknown>).steering) &&
+    Array.isArray((event.properties as Record<string, unknown>).followUp)
+  )
 }
 
 /**
@@ -469,6 +495,10 @@ export function isEventQuestionRejected(event: Event): event is Event & EventQue
  */
 export function extractSessionId(event: Event): string | null {
   // Handle known event types first with type guards
+  if (isEventPromptQueueUpdated(event)) {
+    return event.properties.sessionID ?? null
+  }
+
   if (isEventMessagePartUpdated(event)) {
     return event.properties.part.sessionID ?? null
   }

--- a/apps/desktop/src/lib/generated-screen-loader.test.ts
+++ b/apps/desktop/src/lib/generated-screen-loader.test.ts
@@ -1,0 +1,56 @@
+import fsp from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { loadDesignsForSession } from "../../electron/ipc/designs"
+
+let tempDir: string
+
+async function writeScreen(relativePath: string, title: string, type: "web" | "mobile" = "web") {
+  const filePath = path.join(tempDir, relativePath)
+  await fsp.mkdir(path.dirname(filePath), { recursive: true })
+  await fsp.writeFile(
+    filePath,
+    `<!doctype html><html data-title="${title}" data-screen-type="${type}"><body>${title}</body></html>`,
+  )
+  return filePath
+}
+
+describe("generated screen loader", () => {
+  beforeEach(async () => {
+    tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "dilag-designs-"))
+  })
+
+  afterEach(async () => {
+    await fsp.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it("loads canonical .designs screens and legacy screens fallback files", async () => {
+    const canonical = await writeScreen(".designs/home.html", "Home")
+    const legacy = await writeScreen("screens/legacy.html", "Legacy")
+    await writeScreen("home.html", "Root")
+    await writeScreen("src/ignored.html", "Ignored")
+
+    const designs = await loadDesignsForSession(tempDir)
+
+    expect(designs.map((design) => design.file_path).sort()).toEqual([canonical, legacy].sort())
+    expect(designs.map((design) => design.title).sort()).toEqual(["Home", "Legacy"])
+  })
+
+  it("uses screens as fallback only when canonical and legacy files have the same screen path", async () => {
+    const canonical = await writeScreen(".designs/home.html", "Canonical Home")
+    const duplicateLegacy = await writeScreen("screens/home.html", "Legacy Home")
+    const uniqueLegacy = await writeScreen("screens/settings.html", "Legacy Settings")
+
+    const designs = await loadDesignsForSession(tempDir)
+    const loadedPaths = designs.map((design) => design.file_path)
+
+    expect(loadedPaths).toContain(canonical)
+    expect(loadedPaths).toContain(uniqueLegacy)
+    expect(loadedPaths).not.toContain(duplicateLegacy)
+    expect(designs.map((design) => design.title).sort()).toEqual([
+      "Canonical Home",
+      "Legacy Settings",
+    ])
+  })
+})

--- a/apps/desktop/src/lib/generated-screen-policy.test.ts
+++ b/apps/desktop/src/lib/generated-screen-policy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+import {
+  GENERATED_SCREEN_CANONICAL_DIR,
+  GENERATED_SCREEN_LEGACY_FALLBACK_DIRS,
+  classifyGeneratedScreenFile,
+  getGeneratedScreenDirectories,
+  isGeneratedScreenFile,
+  renderGeneratedScreenOutputRules,
+} from "@dilag/desktop-bridge"
+
+describe("generated screen policy", () => {
+  it("classifies canonical .designs HTML files", () => {
+    expect(
+      classifyGeneratedScreenFile("/sessions/abc/.designs/home.html", "/sessions/abc"),
+    ).toMatchObject({
+      kind: "canonical",
+      directory: ".designs",
+      relativePath: ".designs/home.html",
+      screenPath: "home.html",
+    })
+    expect(isGeneratedScreenFile(".designs/nested/home.html", "/sessions/abc")).toBe(true)
+  })
+
+  it("classifies legacy screens HTML files as fallback display files", () => {
+    expect(
+      classifyGeneratedScreenFile("/sessions/abc/screens/home.html", "/sessions/abc"),
+    ).toMatchObject({
+      kind: "legacy-fallback",
+      directory: "screens",
+      relativePath: "screens/home.html",
+      screenPath: "home.html",
+    })
+    expect(isGeneratedScreenFile("screens/home.html", "/sessions/abc")).toBe(true)
+  })
+
+  it("ignores root HTML, non-HTML, and unrelated nested HTML files", () => {
+    expect(isGeneratedScreenFile("/sessions/abc/home.html", "/sessions/abc")).toBe(false)
+    expect(isGeneratedScreenFile("/sessions/abc/.designs/home.png", "/sessions/abc")).toBe(false)
+    expect(isGeneratedScreenFile("/sessions/abc/src/home.html", "/sessions/abc")).toBe(false)
+  })
+
+  it("returns canonical search directories before legacy fallback directories", () => {
+    expect(getGeneratedScreenDirectories("/sessions/abc")).toEqual([
+      { kind: "canonical", name: GENERATED_SCREEN_CANONICAL_DIR, path: "/sessions/abc/.designs" },
+      {
+        kind: "legacy-fallback",
+        name: GENERATED_SCREEN_LEGACY_FALLBACK_DIRS[0],
+        path: "/sessions/abc/screens",
+      },
+    ])
+  })
+
+  it("renders contract output rules from the canonical and fallback policy", () => {
+    const rules = renderGeneratedScreenOutputRules()
+
+    expect(rules).toContain("`.designs/<kebab-name>.html`")
+    expect(rules).toContain("`screens/` is deprecated fallback for display only")
+    expect(rules).toContain("Never create new screens there")
+  })
+})

--- a/apps/desktop/src/lib/prompt-delivery.test.ts
+++ b/apps/desktop/src/lib/prompt-delivery.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  buildDilagPromptPayload,
+  deliverDilagPrompt,
+  getPromptDeliveryMode,
+  queuedFollowUpPreview,
+} from "./prompt-delivery"
+
+function htmlFile(filename: string, html: string) {
+  return {
+    type: "file" as const,
+    filename,
+    mediaType: "text/html",
+    url: `data:text/html;base64,${btoa(html)}`,
+  }
+}
+
+describe("prompt delivery", () => {
+  it("builds first-message skill hints for the session platform", () => {
+    const payload = buildDilagPromptPayload({
+      content: "Design a login screen",
+      platform: "mobile",
+      isFirstMessage: true,
+    })
+
+    expect(payload.text).toBe("/skill:dilag-mobile-design Design a login screen")
+    expect(payload.images).toEqual([])
+  })
+
+  it("appends screen contexts while keeping the display preview to the visible prompt", () => {
+    const payload = buildDilagPromptPayload({
+      content: "Make the hero calmer",
+      platform: "web",
+      isFirstMessage: true,
+      files: [htmlFile("Home.html", "<html><body><main>Hero</main></body></html>")],
+    })
+
+    expect(payload.text).toContain("/skill:dilag-web-design @Home Make the hero calmer")
+    expect(payload.text).toContain('<screen_context name="Home">')
+    expect(payload.text).toContain("</screen_context>")
+    expect(queuedFollowUpPreview(payload.text)).toBe("@Home Make the hero calmer")
+  })
+
+  it("previews expanded skill-block prompts by showing only the user message", () => {
+    const queuedPrompt =
+      '<skill name="dilag-web-design" location="/skills/web/SKILL.md">\nSkill instructions\n</skill>\n\n@Home Polish copy\n\n<screen_context name="Home">...</screen_context>'
+
+    expect(queuedFollowUpPreview(queuedPrompt)).toBe("@Home Polish copy")
+  })
+
+  it("uses follow-up delivery only while the session is busy", () => {
+    expect(getPromptDeliveryMode({ sessionStatus: "idle", hasRunningTools: false })).toBe(
+      "immediate",
+    )
+    expect(getPromptDeliveryMode({ sessionStatus: "unknown", hasRunningTools: true })).toBe(
+      "followUp",
+    )
+    expect(getPromptDeliveryMode({ sessionStatus: "running", hasRunningTools: false })).toBe(
+      "followUp",
+    )
+  })
+
+  it("passes Pi streamingBehavior only for queued follow-ups", async () => {
+    const prompt = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      deliverDilagPrompt({
+        agentBridge: { prompt },
+        session: { id: "session-1", cwd: "/project", platform: "web" },
+        content: "Queue this",
+        isFirstMessage: false,
+        sessionStatus: "running",
+        hasRunningTools: false,
+        model: null,
+      }),
+    ).resolves.toEqual({ mode: "followUp", status: "queued" })
+
+    expect(prompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionID: "session-1",
+        directory: "/project",
+        text: "Queue this",
+        streamingBehavior: "followUp",
+      }),
+    )
+
+    prompt.mockClear()
+
+    await expect(
+      deliverDilagPrompt({
+        agentBridge: { prompt },
+        session: { id: "session-1", cwd: "/project", platform: "web" },
+        content: "Send now",
+        isFirstMessage: false,
+        sessionStatus: "idle",
+        hasRunningTools: false,
+        model: null,
+      }),
+    ).resolves.toEqual({ mode: "immediate", status: "accepted" })
+
+    expect(prompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Send now",
+        streamingBehavior: undefined,
+      }),
+    )
+  })
+})

--- a/apps/desktop/src/lib/prompt-delivery.ts
+++ b/apps/desktop/src/lib/prompt-delivery.ts
@@ -1,0 +1,228 @@
+import type { AgentImageContent, AgentThinkingLevel, Platform } from "@dilag/desktop-bridge"
+import type { FileUIPart } from "ai"
+import type { SessionStatus } from "@/context/session-store"
+import { bridge } from "@/lib/bridge"
+import { formatElementWithAncestry, minifyHtml } from "@/lib/html-utils"
+
+export type PromptDeliveryMode = "immediate" | "followUp"
+export type PromptDeliveryStatus = "accepted" | "queued"
+
+export interface PromptDeliveryOutcome {
+  mode: PromptDeliveryMode
+  status: PromptDeliveryStatus
+}
+
+export interface PromptDeliverySession {
+  id: string
+  cwd: string
+  platform?: Platform
+}
+
+export interface PromptDeliveryModel {
+  providerID: string
+  modelID: string
+}
+
+export interface PromptDeliveryAgentBridge {
+  prompt(args: {
+    sessionID: string
+    directory: string
+    text: string
+    images?: AgentImageContent[]
+    model?: PromptDeliveryModel | null
+    thinkingLevel?: AgentThinkingLevel
+    streamingBehavior?: "steer" | "followUp"
+  }): Promise<void>
+}
+
+export interface BuildDilagPromptPayloadArgs {
+  content: string
+  files?: FileUIPart[]
+  platform?: Platform
+  isFirstMessage: boolean
+}
+
+export interface DilagPromptPayload {
+  text: string
+  images: AgentImageContent[]
+}
+
+export interface PromptDeliveryArgs extends BuildDilagPromptPayloadArgs {
+  session: PromptDeliverySession
+  sessionStatus: SessionStatus
+  hasRunningTools: boolean
+  model?: PromptDeliveryModel | null
+  thinkingLevel?: AgentThinkingLevel
+  agentBridge?: PromptDeliveryAgentBridge
+}
+
+type ElementSelectionInfo = {
+  selector: string
+  html: string
+  tagName: string
+  ancestorPath?: string[]
+}
+
+export function getPromptDeliveryMode(args: {
+  sessionStatus: SessionStatus
+  hasRunningTools: boolean
+}): PromptDeliveryMode {
+  return args.sessionStatus === "running" || args.sessionStatus === "busy" || args.hasRunningTools
+    ? "followUp"
+    : "immediate"
+}
+
+export function buildDilagPromptPayload({
+  content,
+  files,
+  platform = "web",
+  isFirstMessage,
+}: BuildDilagPromptPayloadArgs): DilagPromptPayload {
+  const skillHint = isFirstMessage ? `/skill:dilag-${platform}-design ` : ""
+  let promptText = skillHint + content
+
+  const screenContexts: string[] = []
+  const screenNames: string[] = []
+  const fileNotes: string[] = []
+  const images: AgentImageContent[] = []
+
+  for (const file of files ?? []) {
+    if (!file.url) continue
+
+    if (file.mediaType === "text/html") {
+      appendHtmlScreenContext(file, screenNames, screenContexts)
+      continue
+    }
+
+    if (file.mediaType?.startsWith("image/")) {
+      const dataUrlMatch = file.url.match(/^data:([^;,]+);base64,(.+)$/)
+      if (dataUrlMatch) {
+        images.push({
+          type: "image",
+          mimeType: dataUrlMatch[1] || file.mediaType,
+          data: dataUrlMatch[2],
+        })
+      } else if (file.filename) {
+        fileNotes.push(`Attached image not inlined: ${file.filename}`)
+      }
+      continue
+    }
+
+    if (file.filename) {
+      fileNotes.push(`Attached file not inlined: ${file.filename}`)
+    }
+  }
+
+  if (screenNames.length > 0) {
+    const inlineRefs = screenNames.map((name) => `@${name}`).join(" ")
+    const contextBlock = screenContexts.join("\n\n")
+    promptText = `${skillHint}${inlineRefs} ${content}\n\n${contextBlock}`
+  }
+
+  if (fileNotes.length > 0) {
+    promptText += `\n\n${fileNotes.join("\n")}`
+  }
+
+  return { text: promptText, images }
+}
+
+export async function deliverDilagPrompt({
+  session,
+  sessionStatus,
+  hasRunningTools,
+  model,
+  thinkingLevel,
+  agentBridge = bridge.agent,
+  ...payloadArgs
+}: PromptDeliveryArgs): Promise<PromptDeliveryOutcome> {
+  const payload = buildDilagPromptPayload({
+    ...payloadArgs,
+    platform: payloadArgs.platform ?? session.platform ?? "web",
+  })
+  const mode = getPromptDeliveryMode({ sessionStatus, hasRunningTools })
+
+  await agentBridge.prompt({
+    sessionID: session.id,
+    directory: session.cwd,
+    text: payload.text,
+    images: payload.images,
+    model,
+    thinkingLevel,
+    streamingBehavior: mode === "followUp" ? "followUp" : undefined,
+  })
+
+  return {
+    mode,
+    status: mode === "followUp" ? "queued" : "accepted",
+  }
+}
+
+export function queuedFollowUpPreview(prompt: string): string {
+  const expandedSkillBlock = prompt.match(
+    /^<skill name="[^"]+" location="[^"]+">\n[\s\S]*?\n<\/skill>(?:\n\n([\s\S]+))?$/,
+  )
+  const displayPrompt = expandedSkillBlock
+    ? (expandedSkillBlock[1] ?? "")
+    : prompt.replace(/^\/skill:dilag-(web|mobile)-design\s+/, "")
+  const firstDisplayBlock = displayPrompt.split(/\n\s*\n/)[0]?.trim()
+  return firstDisplayBlock || "(attached context)"
+}
+
+function appendHtmlScreenContext(
+  file: FileUIPart,
+  screenNames: string[],
+  screenContexts: string[],
+): void {
+  const base64Match = file.url?.match(/^data:text\/html;base64,(.+)$/)
+  if (!base64Match) return
+
+  try {
+    let htmlContent = decodeBase64Utf8(base64Match[1])
+    const screenName = file.filename?.replace(/\.html$/i, "") || "Screen"
+    const elementInfo = extractElementSelection(htmlContent)
+
+    if (elementInfo) {
+      htmlContent = htmlContent.replace(elementInfo.marker, "").trim()
+      const compactElement = formatElementWithAncestry(
+        elementInfo.info.html,
+        elementInfo.info.ancestorPath,
+      )
+      screenNames.push(`${screenName} (${elementInfo.info.tagName})`)
+      screenContexts.push(
+        `<edit_element screen="${screenName}" selector="${elementInfo.info.selector}">\n` +
+          `${compactElement}\n` +
+          `</edit_element>`,
+      )
+      return
+    }
+
+    const minifiedHtml = minifyHtml(htmlContent)
+    screenNames.push(screenName)
+    screenContexts.push(`<screen_context name="${screenName}">${minifiedHtml}</screen_context>`)
+  } catch (error) {
+    console.error("[prompt-delivery] Failed to decode HTML content:", error)
+  }
+}
+
+function extractElementSelection(
+  htmlContent: string,
+): { marker: string; info: ElementSelectionInfo } | null {
+  const markerMatch = htmlContent.match(/<!-- dilag-element-selection: ({.*?}) -->/)
+  if (!markerMatch) return null
+
+  try {
+    return {
+      marker: markerMatch[0],
+      info: JSON.parse(markerMatch[1]) as ElementSelectionInfo,
+    }
+  } catch (error) {
+    console.error("[prompt-delivery] Failed to parse element selection marker:", error)
+    return null
+  }
+}
+
+function decodeBase64Utf8(value: string): string {
+  const binary = atob(value)
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0))
+  return new TextDecoder().decode(bytes)
+}

--- a/apps/desktop/src/lib/screen-layout.test.ts
+++ b/apps/desktop/src/lib/screen-layout.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest"
+import {
+  findMissingScreenPositions,
+  getGhostScreenPosition,
+  getScreenLayout,
+  reconcileScreenPositions,
+  type ScreenPosition,
+} from "./screen-layout"
+
+const designs = (filenames: string[]) => filenames.map((filename) => ({ filename }))
+
+describe("screen layout", () => {
+  it("preserves existing persisted positions", () => {
+    const persistedPositions: ScreenPosition[] = [
+      { id: "home.html", x: 12, y: 34 },
+      { id: "settings.html", x: 56, y: 78 },
+    ]
+
+    expect(
+      reconcileScreenPositions({
+        designs: designs(["home.html", "settings.html"]),
+        persistedPositions,
+        platform: "web",
+      }),
+    ).toEqual(persistedPositions)
+  })
+
+  it("derives missing positions deterministically from design order", () => {
+    expect(
+      findMissingScreenPositions({
+        designs: designs(["home.html", "settings.html", "profile.html"]),
+        persistedPositions: [{ id: "settings.html", x: 5000, y: 6000 }],
+        platform: "web",
+      }),
+    ).toEqual([
+      { id: "home.html", x: 100, y: 40 },
+      { id: "profile.html", x: 100, y: 500 },
+    ])
+  })
+
+  it("does not return render positions for removed designs", () => {
+    expect(
+      reconcileScreenPositions({
+        designs: designs(["home.html"]),
+        persistedPositions: [
+          { id: "home.html", x: 12, y: 34 },
+          { id: "removed.html", x: 56, y: 78 },
+        ],
+        platform: "web",
+      }),
+    ).toEqual([{ id: "home.html", x: 12, y: 34 }])
+  })
+
+  it("places the ghost after the current screens", () => {
+    const screenPositions = reconcileScreenPositions({
+      designs: designs(["home.html", "settings.html", "profile.html"]),
+      persistedPositions: [],
+      platform: "web",
+    })
+
+    expect(getGhostScreenPosition({ screenPositions, platform: "web" })).toEqual({
+      x: 800,
+      y: 500,
+    })
+  })
+
+  it("uses different mobile and web dimensions and columns", () => {
+    expect(getScreenLayout("mobile")).toMatchObject({
+      screen: { width: 280, height: 584 },
+      columns: 4,
+      gap: 60,
+    })
+    expect(getScreenLayout("web")).toMatchObject({
+      screen: { width: 640, height: 400 },
+      columns: 2,
+      gap: 60,
+    })
+  })
+})

--- a/apps/desktop/src/lib/screen-layout.ts
+++ b/apps/desktop/src/lib/screen-layout.ts
@@ -1,0 +1,131 @@
+export type ScreenPlatform = "mobile" | "web"
+
+export interface ScreenPosition {
+  id: string
+  x: number
+  y: number
+}
+
+export interface ScreenLayoutDesign {
+  filename: string
+}
+
+export interface ScreenLayout {
+  screen: {
+    width: number
+    height: number
+  }
+  gap: number
+  columns: number
+  start: {
+    x: number
+    y: number
+  }
+}
+
+interface ScreenPositionsArgs {
+  designs: readonly ScreenLayoutDesign[]
+  persistedPositions: readonly ScreenPosition[]
+  platform: ScreenPlatform
+}
+
+const START = { x: 100, y: 40 }
+const GAP = 60
+
+const SCREEN_LAYOUTS: Record<ScreenPlatform, ScreenLayout> = {
+  mobile: {
+    screen: { width: 280, height: 584 },
+    gap: GAP,
+    columns: 4,
+    start: START,
+  },
+  web: {
+    screen: { width: 640, height: 400 },
+    gap: GAP,
+    columns: 2,
+    start: START,
+  },
+}
+
+export function getScreenLayout(platform: ScreenPlatform): ScreenLayout {
+  const layout = SCREEN_LAYOUTS[platform]
+
+  return {
+    screen: { ...layout.screen },
+    gap: layout.gap,
+    columns: layout.columns,
+    start: { ...layout.start },
+  }
+}
+
+function getDefaultScreenPosition(
+  id: string,
+  index: number,
+  platform: ScreenPlatform,
+): ScreenPosition {
+  const layout = SCREEN_LAYOUTS[platform]
+  const col = index % layout.columns
+  const row = Math.floor(index / layout.columns)
+
+  return {
+    id,
+    x: layout.start.x + col * (layout.screen.width + layout.gap),
+    y: layout.start.y + row * (layout.screen.height + layout.gap),
+  }
+}
+
+export function reconcileScreenPositions({
+  designs,
+  persistedPositions,
+  platform,
+}: ScreenPositionsArgs): ScreenPosition[] {
+  const persistedPositionById = new Map(
+    persistedPositions.map((position) => [position.id, position]),
+  )
+
+  return designs.map((design, index) => {
+    const persistedPosition = persistedPositionById.get(design.filename)
+
+    if (persistedPosition) {
+      return {
+        id: persistedPosition.id,
+        x: persistedPosition.x,
+        y: persistedPosition.y,
+      }
+    }
+
+    return getDefaultScreenPosition(design.filename, index, platform)
+  })
+}
+
+export function findMissingScreenPositions(args: ScreenPositionsArgs): ScreenPosition[] {
+  const persistedIds = new Set(args.persistedPositions.map((position) => position.id))
+
+  return reconcileScreenPositions(args).filter((position) => !persistedIds.has(position.id))
+}
+
+export function getGhostScreenPosition({
+  screenPositions,
+  platform,
+}: {
+  screenPositions: readonly ScreenPosition[]
+  platform: ScreenPlatform
+}): { x: number; y: number } {
+  const layout = SCREEN_LAYOUTS[platform]
+  const count = screenPositions.length
+  const col = count % layout.columns
+  const row = Math.floor(count / layout.columns)
+  const startX =
+    screenPositions.length > 0
+      ? Math.min(...screenPositions.map((position) => position.x))
+      : layout.start.x
+  const startY =
+    screenPositions.length > 0
+      ? Math.min(...screenPositions.map((position) => position.y))
+      : layout.start.y
+
+  return {
+    x: startX + col * (layout.screen.width + layout.gap),
+    y: startY + row * (layout.screen.height + layout.gap),
+  }
+}

--- a/apps/desktop/src/routes/__root.tsx
+++ b/apps/desktop/src/routes/__root.tsx
@@ -34,10 +34,13 @@ function RootLayout() {
               "--traffic-light-gap": "10px",
               "--titlebar-control-gap": "12px",
               "--titlebar-control-size": "24px",
-              "--titlebar-control-left": "calc(var(--traffic-light-left) + (var(--traffic-light-size) * 3) + (var(--traffic-light-gap) * 2) + var(--titlebar-control-gap))",
+              "--titlebar-control-left":
+                "calc(var(--traffic-light-left) + (var(--traffic-light-size) * 3) + (var(--traffic-light-gap) * 2) + var(--titlebar-control-gap))",
               "--titlebar-control-offset-y": "1px",
-              "--titlebar-control-center-y": "calc(var(--traffic-light-top) + (var(--traffic-light-size) / 2) + var(--titlebar-control-offset-y))",
-              "--titlebar-content-left": "calc(var(--titlebar-control-left) + var(--titlebar-control-size) + 4px)",
+              "--titlebar-control-center-y":
+                "calc(var(--traffic-light-top) + (var(--traffic-light-size) / 2) + var(--titlebar-control-offset-y))",
+              "--titlebar-content-left":
+                "calc(var(--titlebar-control-left) + var(--titlebar-control-size) + 4px)",
             } as CSSProperties
           }
         >

--- a/apps/desktop/src/routes/__root.tsx
+++ b/apps/desktop/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { NuqsAdapter } from "nuqs/adapters/tanstack-router"
 import { SidebarProvider, SidebarInset } from "@dilag/ui/sidebar"
 import { AppSidebar } from "@/components/blocks/layout/app-sidebar"
 import { AutoCollapseSidebar } from "@/components/blocks/layout/auto-collapse-sidebar"
+import { PersistentSidebarTrigger } from "@/components/blocks/layout/persistent-sidebar-trigger"
 import { AppProviders } from "@/components/app-providers"
 import { useZoom } from "@/hooks/use-zoom"
 
@@ -22,10 +23,28 @@ function RootLayout() {
   return (
     <AppProviders>
       <NuqsAdapter>
-        <SidebarProvider defaultOpen={true} style={{ "--sidebar-width": "19rem" } as CSSProperties}>
+        <SidebarProvider
+          defaultOpen={true}
+          style={
+            {
+              "--sidebar-width": "19rem",
+              "--traffic-light-left": "16px",
+              "--traffic-light-top": "15px",
+              "--traffic-light-size": "12px",
+              "--traffic-light-gap": "10px",
+              "--titlebar-control-gap": "12px",
+              "--titlebar-control-size": "24px",
+              "--titlebar-control-left": "calc(var(--traffic-light-left) + (var(--traffic-light-size) * 3) + (var(--traffic-light-gap) * 2) + var(--titlebar-control-gap))",
+              "--titlebar-control-offset-y": "1px",
+              "--titlebar-control-center-y": "calc(var(--traffic-light-top) + (var(--traffic-light-size) / 2) + var(--titlebar-control-offset-y))",
+              "--titlebar-content-left": "calc(var(--titlebar-control-left) + var(--titlebar-control-size) + 4px)",
+            } as CSSProperties
+          }
+        >
           <AutoCollapseSidebar />
           <AppSidebar />
-          <SidebarInset className="h-svh overflow-hidden border border-border/80 bg-background shadow-sm ring-1 ring-white/5">
+          <PersistentSidebarTrigger />
+          <SidebarInset className="min-h-0 overflow-hidden bg-background">
             <Outlet />
           </SidebarInset>
         </SidebarProvider>

--- a/apps/desktop/src/routes/index.tsx
+++ b/apps/desktop/src/routes/index.tsx
@@ -65,7 +65,7 @@ function HomePage() {
 
   return (
     <div className="h-full flex flex-col bg-background relative overflow-hidden">
-      <PageHeader />
+      <PageHeader className="border-b-0" />
       <main className="flex-1 overflow-auto px-8 py-10">
         <div className="mx-auto flex min-h-full w-full max-w-5xl items-center">
           <div className="grid w-full gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
@@ -180,7 +180,7 @@ function HomePage() {
 function HomeLoadingState() {
   return (
     <div className="h-full flex flex-col bg-background">
-      <PageHeader />
+      <PageHeader className="border-b-0" />
       <main className="flex-1 flex items-center justify-center">
         <div className="flex flex-col items-center gap-3 text-sm text-muted-foreground">
           <DilagIcon animated className="size-9 text-primary" />

--- a/apps/desktop/src/routes/project.$projectId.tsx
+++ b/apps/desktop/src/routes/project.$projectId.tsx
@@ -15,11 +15,12 @@ import { PageHeader } from "@/components/blocks/layout/page-header"
 import { AgentSelectorButton } from "@/components/blocks/selectors/agent-selector-button"
 import { ModelSelectorButton } from "@/components/blocks/selectors/model-selector-button"
 import { ThinkingModeSelector } from "@/components/blocks/selectors/thinking-mode-selector"
+import { useNewDesignFlow } from "@/features/new-design/use-new-design-flow"
 import { useProjectMutations, useProjectsList } from "@/hooks/use-projects"
 import { useSessions } from "@/hooks/use-sessions"
 import { cn } from "@/lib/utils"
 import { ArrowUp, Monitor, Smartphone } from "@solar-icons/react"
-import { createFileRoute, Outlet, useMatch, useNavigate, useParams } from "@tanstack/react-router"
+import { createFileRoute, Outlet, useMatch, useParams } from "@tanstack/react-router"
 import type { FileUIPart } from "ai"
 import { useEffect } from "react"
 
@@ -33,36 +34,25 @@ function ProjectComposerPage() {
     from: "/project/$projectId/session/$sessionId",
     shouldThrow: false,
   })
-  const navigate = useNavigate()
   const { data: projects = [], isLoading: isLoadingProjects } = useProjectsList()
   const { updateProject, touchProject } = useProjectMutations()
   const { createSessionInProject, isServerReady } = useSessions()
+  const { rememberProject, submitProjectComposer } = useNewDesignFlow({
+    projects,
+    touchProject,
+    createSessionInProject,
+  })
   const project = projects.find((item) => item.id === projectId)
 
   useEffect(() => {
     if (project) {
-      localStorage.setItem("dilag-last-project-id", project.id)
+      rememberProject(project.id)
     }
-  }, [project])
+  }, [project, rememberProject])
 
   const handleSubmit = async (text: string, files?: FileUIPart[]) => {
-    if (!project || (!text.trim() && (!files || files.length === 0))) return
-    localStorage.setItem("dilag-initial-prompt", text)
-    localStorage.setItem("dilag-initial-platform", project.platform)
-    if (files && files.length > 0) {
-      localStorage.setItem("dilag-initial-files", JSON.stringify(files))
-    } else {
-      localStorage.removeItem("dilag-initial-files")
-    }
-
-    await touchProject(project.id)
-    const sessionId = await createSessionInProject(project)
-    if (sessionId) {
-      navigate({
-        to: "/project/$projectId/session/$sessionId",
-        params: { projectId: project.id, sessionId },
-      })
-    }
+    if (!project) return
+    await submitProjectComposer(project, text, files)
   }
 
   if (sessionRouteMatch) {
@@ -72,7 +62,7 @@ function ProjectComposerPage() {
   if (!project) {
     return (
       <div className="h-full flex flex-col bg-background">
-        <PageHeader />
+        <PageHeader className="border-b-0" />
         <main className="flex-1 flex items-center justify-center text-sm text-muted-foreground">
           {isLoadingProjects ? "Opening your workspace…" : "Project not found"}
         </main>
@@ -82,7 +72,7 @@ function ProjectComposerPage() {
 
   return (
     <div className="h-full flex flex-col bg-background relative overflow-hidden">
-      <PageHeader />
+      <PageHeader className="border-b-0" />
       <main className="relative flex-1 flex flex-col overflow-auto">
         <div className="flex-1 flex items-center justify-center px-6 py-16">
           <div className="w-full max-w-2xl">

--- a/apps/desktop/src/routes/studio.$sessionId.tsx
+++ b/apps/desktop/src/routes/studio.$sessionId.tsx
@@ -52,6 +52,8 @@ import { AttachmentBridgeProvider } from "@/context/attachment-bridge"
 import { ScreenCaptureProvider, useScreenCaptureContext } from "@/context/screen-capture-context"
 import { toast } from "sonner"
 import { bridge } from "@/lib/bridge"
+import { findMissingScreenPositions } from "@/lib/screen-layout"
+import { getCanonicalGeneratedScreenPath } from "@dilag/desktop-bridge"
 
 export const Route = createFileRoute("/studio/$sessionId")({
   component: StudioRoutePage,
@@ -61,17 +63,6 @@ function StudioRoutePage() {
   const { sessionId } = useParams({ from: "/studio/$sessionId" })
   return <StudioPageContent sessionId={sessionId} />
 }
-
-// Layout constants
-const MOBILE_WIDTH = 280
-const MOBILE_HEIGHT = 584
-const WEB_WIDTH = 640
-const WEB_HEIGHT = 400
-const GAP = 60
-const START_X = 100
-const START_Y = 40
-const MOBILE_COLUMNS = 4
-const WEB_COLUMNS = 2
 
 export function StudioPageContent({
   sessionId,
@@ -128,34 +119,19 @@ export function StudioPageContent({
     selectSession(sessionId)
   }, [sessionId, selectSession])
 
-  // Sync screen positions when designs change
+  // Persist positions for newly discovered designs. Rendering does not depend on this:
+  // DesignCanvas reconciles temporary positions while storage/session state hydrates.
   useEffect(() => {
     if (designs.length === 0) return
 
-    const existingIds = screenPositions.map((p) => p.id)
-    const newDesigns = designs.filter((d) => !existingIds.includes(d.filename))
+    const missingPositions = findMissingScreenPositions({
+      designs,
+      persistedPositions: screenPositions,
+      platform: currentSession?.platform ?? "web",
+    })
 
-    if (newDesigns.length > 0) {
-      // Position new screens in grid after existing ones
-      const startIndex = existingIds.length
-      const isMobile = currentSession?.platform === "mobile"
-      const width = isMobile ? MOBILE_WIDTH : WEB_WIDTH
-      const height = isMobile ? MOBILE_HEIGHT : WEB_HEIGHT
-      const columns = isMobile ? MOBILE_COLUMNS : WEB_COLUMNS
-
-      const newPositions = newDesigns.map((design, i) => {
-        const index = startIndex + i
-        const col = index % columns
-        const row = Math.floor(index / columns)
-
-        return {
-          id: design.filename,
-          x: START_X + col * (width + GAP),
-          y: START_Y + row * (height + GAP),
-        }
-      })
-
-      setScreenPositions(sessionId, [...screenPositions, ...newPositions])
+    if (missingPositions.length > 0) {
+      setScreenPositions(sessionId, [...screenPositions, ...missingPositions])
     }
   }, [designs, screenPositions, sessionId, setScreenPositions, currentSession?.platform])
 
@@ -170,7 +146,9 @@ export function StudioPageContent({
     if (!deleteTarget || !currentSession?.cwd) return
 
     const design = designs.find((item) => item.filename === deleteTarget.filename)
-    const filePath = design?.file_path ?? `${currentSession.cwd}/.designs/${deleteTarget.filename}`
+    const filePath =
+      design?.file_path ??
+      getCanonicalGeneratedScreenPath(currentSession.cwd, deleteTarget.filename)
     try {
       await bridge.designs.delete({ filePath })
       // Remove from positions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,7 +62,9 @@ Dilag-owned app state lives under `~/.dilag/`; generated designs live in project
 └── skills/                        # Built-in Dilag design skills for Pi
 
 {project-cwd}/
-└── .designs/                      # Generated HTML screens
+├── .designs/                      # Canonical generated HTML screens
+│   └── **/*.html
+└── screens/                       # Legacy fallback display only
     └── **/*.html
 ```
 
@@ -96,7 +98,7 @@ This keeps chat rendering, tool rendering, project-file diff badges, and the que
 5. Prompts are sent through `bridge.agent.prompt()` with the selected model and optional image attachments.
 6. Pi streams normalized events back through `bridge.agent.onEvent()`.
 7. Pi tools write generated screens into `{project-cwd}/.designs/`.
-8. The design loader reads `{project-cwd}/.designs/**/*.html` from disk and updates the canvas.
+8. The design loader reads canonical `{project-cwd}/.designs/**/*.html` files, then legacy fallback `{project-cwd}/screens/**/*.html` files, and updates the canvas.
 
 ## Messages And Timeline
 
@@ -110,13 +112,9 @@ Tree navigation replaces the old revert/unrevert model. Timeline actions call `b
 
 ## Generated Output
 
-Generated screens are plain HTML files in the active project cwd:
+Generated screens are plain HTML files in the active project cwd. `.designs/**/*.html` is canonical for all new and updated output. `screens/**/*.html` is deprecated and loaded only as a legacy fallback so older or mistaken runs do not leave the canvas empty.
 
-```text
-{project-cwd}/.designs/**/*.html
-```
-
-The canvas preview is runtime-independent. If valid screen files exist, the renderer can display them regardless of which agent runtime produced them.
+The canvas preview is runtime-independent. If valid screen files exist in those display locations, the renderer can display them regardless of which agent runtime produced them.
 
 ## Quality Gates
 

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -7,7 +7,7 @@ Dilag is an AI-powered design studio for mobile and web apps. The desktop app tu
 A Dilag project is a local folder registered in SQLite with:
 
 - project metadata in `~/.dilag/state.sqlite`
-- generated screen files in `{project-cwd}/.designs/**/*.html`
+- canonical generated screen files in `{project-cwd}/.designs/**/*.html` (`screens/**/*.html` is legacy fallback display only)
 - chat history backed by the embedded agent runtime under `~/.dilag/pi`
 - Dilag design skills loaded from `~/.dilag/skills`
 
@@ -35,7 +35,7 @@ Web:          Next.js 16 marketing site
 4. Dilag creates or selects a project cwd and starts an agent session there.
 5. The first prompt activates the matching design skill.
 6. The agent writes HTML screens into `{project-cwd}/.designs/`.
-7. The canvas renders generated screens.
+7. The canvas renders `.designs/**/*.html`, plus legacy `screens/**/*.html` fallback files when present.
 8. User continues iterating through chat in Studio.
 
 ## Runtime Flow
@@ -46,7 +46,7 @@ Web:          Next.js 16 marketing site
 4. The Electron host creates or opens an agent session in the selected project cwd.
 5. First prompt is prefixed with `/skill:dilag-web-design` or `/skill:dilag-mobile-design`.
 6. Agent tools write HTML into `{project-cwd}/.designs/`.
-7. The design loader reads generated files and refreshes the canvas.
+7. The design loader reads canonical `.designs/**/*.html` files, falls back to legacy `screens/**/*.html` display files, and refreshes the canvas.
 8. Follow-up chat prompts update or add screens in the same project cwd.
 
 ## Agent Bridge
@@ -99,13 +99,9 @@ Runtime permission prompts are intentionally skipped for the Pi path. Tool scope
 
 ## Generated Output
 
-Generated screens are plain HTML files in the active project cwd:
+Generated screens are plain HTML files in the active project cwd. `.designs/**/*.html` is canonical for all new and updated output. `screens/**/*.html` is deprecated and loaded only as a legacy fallback.
 
-```text
-{project-cwd}/.designs/**/*.html
-```
-
-The preview system is runtime-independent: if the files exist and validate, the canvas can render them.
+The preview system is runtime-independent: if files exist in those display locations and validate, the canvas can render them.
 
 ## Session Tree
 
@@ -123,6 +119,7 @@ Use this checklist when validating the desktop app:
 - Studio loads the created session and existing messages.
 - A prompt streams assistant output and tool activity.
 - Generated `.designs/**/*.html` files appear and render on the canvas.
+- Legacy `screens/**/*.html` files still render as fallback display files.
 - Follow-up chat updates or adds screens.
 - Question prompts can be answered or rejected.
 - Abort stops an in-flight prompt cleanly.

--- a/packages/desktop-bridge/src/generated-screen-policy.ts
+++ b/packages/desktop-bridge/src/generated-screen-policy.ts
@@ -1,0 +1,150 @@
+export const GENERATED_SCREEN_CANONICAL_DIR = ".designs"
+export const GENERATED_SCREEN_LEGACY_FALLBACK_DIRS = ["screens"] as const
+export const GENERATED_SCREEN_EXTENSION = ".html"
+
+export type GeneratedScreenDirectoryKind = "canonical" | "legacy-fallback"
+
+export interface GeneratedScreenDirectory {
+  kind: GeneratedScreenDirectoryKind
+  name: string
+  path: string
+}
+
+export interface GeneratedScreenFileMatch {
+  kind: GeneratedScreenDirectoryKind
+  directory: string
+  relativePath: string
+  screenPath: string
+}
+
+export function getCanonicalGeneratedScreenDirectory(projectCwd: string): string {
+  return joinGeneratedScreenPath(projectCwd, GENERATED_SCREEN_CANONICAL_DIR)
+}
+
+export function getCanonicalGeneratedScreenPath(projectCwd: string, screenPath: string): string {
+  return joinGeneratedScreenPath(
+    getCanonicalGeneratedScreenDirectory(projectCwd),
+    stripLeadingDotSlash(normalizeGeneratedScreenPath(screenPath)),
+  )
+}
+
+export function getGeneratedScreenDirectories(projectCwd: string): GeneratedScreenDirectory[] {
+  return [
+    {
+      kind: "canonical",
+      name: GENERATED_SCREEN_CANONICAL_DIR,
+      path: getCanonicalGeneratedScreenDirectory(projectCwd),
+    },
+    ...GENERATED_SCREEN_LEGACY_FALLBACK_DIRS.map((name) => ({
+      kind: "legacy-fallback" as const,
+      name,
+      path: joinGeneratedScreenPath(projectCwd, name),
+    })),
+  ]
+}
+
+export function getGeneratedScreenSearchDirectories(projectCwd: string): string[] {
+  return getGeneratedScreenDirectories(projectCwd).map((directory) => directory.path)
+}
+
+export function classifyGeneratedScreenFile(
+  filePath: string,
+  projectCwd?: string,
+): GeneratedScreenFileMatch | null {
+  const relativePath = toProjectRelativePath(filePath, projectCwd)
+  const lowerRelativePath = relativePath.toLowerCase()
+  if (!lowerRelativePath.endsWith(GENERATED_SCREEN_EXTENSION)) return null
+
+  const [directory, ...screenPathParts] = relativePath.split("/")
+  const screenPath = screenPathParts.join("/")
+  if (!directory || !screenPath) return null
+
+  if (directory === GENERATED_SCREEN_CANONICAL_DIR) {
+    return { kind: "canonical", directory, relativePath, screenPath }
+  }
+
+  if ((GENERATED_SCREEN_LEGACY_FALLBACK_DIRS as readonly string[]).includes(directory)) {
+    return { kind: "legacy-fallback", directory, relativePath, screenPath }
+  }
+
+  return null
+}
+
+export function isGeneratedScreenFile(filePath: string, projectCwd?: string): boolean {
+  return classifyGeneratedScreenFile(filePath, projectCwd) !== null
+}
+
+export function getGeneratedScreenFallbackKey(
+  filePath: string,
+  projectCwd?: string,
+): string | null {
+  return classifyGeneratedScreenFile(filePath, projectCwd)?.screenPath ?? null
+}
+
+export function renderGeneratedScreenOutputRules(): string {
+  const legacyDirs = GENERATED_SCREEN_LEGACY_FALLBACK_DIRS.map((directory) => `\`${directory}/\``)
+  const legacyDirList = legacyDirs.join(", ")
+  return [
+    `- Path: \`${GENERATED_SCREEN_CANONICAL_DIR}/<kebab-name>.html\` relative to the current working directory.`,
+    `- Write generated screens to \`${GENERATED_SCREEN_CANONICAL_DIR}/\` only; create or update files there for all new work.`,
+    `- ${legacyDirList} ${legacyDirs.length === 1 ? "is" : "are"} deprecated fallback for display only. Never create new screens there.`,
+    `- If an existing screen is only in ${legacyDirList}, treat it as legacy and write the updated version under \`${GENERATED_SCREEN_CANONICAL_DIR}/\`.`,
+    "- Do not write generated screens to the project root, `src/`, `public/`, the user home directory, or any absolute path outside the current working directory.",
+  ].join("\n")
+}
+
+export function renderHtmlScreenContract(template: string): string {
+  return template.replaceAll(
+    "{{GENERATED_SCREEN_OUTPUT_RULES}}",
+    renderGeneratedScreenOutputRules(),
+  )
+}
+
+export function renderGeneratedScreenSystemPromptRules(): string {
+  const legacyDirs = GENERATED_SCREEN_LEGACY_FALLBACK_DIRS.map((directory) => `${directory}/`).join(
+    ", ",
+  )
+  return [
+    "- The current working directory is the active Dilag project directory. Treat it as the only workspace.",
+    "- Create and edit design files inside this directory only. Do not write to the user home directory, parent directories, or absolute paths outside the current working directory.",
+    `- Write every generated screen to ${GENERATED_SCREEN_CANONICAL_DIR}/<kebab-name>.html. Do not use ${legacyDirs}, the project root, or any other folder for generated screens.`,
+    `- ${legacyDirs} ${GENERATED_SCREEN_LEGACY_FALLBACK_DIRS.length === 1 ? "is" : "are"} deprecated fallback only. If you see old files there, treat them as legacy and write updated/new screens under ${GENERATED_SCREEN_CANONICAL_DIR}/.`,
+    `- The write tool creates parent directories automatically; do not run mkdir just to create ${GENERATED_SCREEN_CANONICAL_DIR}/.`,
+    `- Before editing an existing screen, inspect the project files and prefer ${GENERATED_SCREEN_CANONICAL_DIR}/*.html.`,
+  ].join("\n")
+}
+
+function toProjectRelativePath(filePath: string, projectCwd?: string): string {
+  const normalizedFile = stripLeadingDotSlash(normalizeGeneratedScreenPath(filePath))
+  if (!projectCwd) return normalizedFile
+
+  const normalizedCwd = normalizeGeneratedScreenPath(projectCwd)
+  if (!normalizedCwd) return normalizedFile
+  if (normalizedFile === normalizedCwd) return ""
+  if (normalizedCwd === "/" && normalizedFile.startsWith("/")) {
+    return stripLeadingDotSlash(normalizedFile.slice(1))
+  }
+  if (normalizedFile.startsWith(`${normalizedCwd}/`)) {
+    return stripLeadingDotSlash(normalizedFile.slice(normalizedCwd.length + 1))
+  }
+
+  return normalizedFile
+}
+
+function joinGeneratedScreenPath(basePath: string, childPath: string): string {
+  const normalizedBase = normalizeGeneratedScreenPath(basePath)
+  if (!normalizedBase || normalizedBase === "/") return `${normalizedBase}${childPath}`
+  return `${normalizedBase}/${childPath}`
+}
+
+function normalizeGeneratedScreenPath(value: string): string {
+  const normalized = value.replace(/\\/g, "/")
+  if (normalized === "/") return normalized
+  return normalized.replace(/\/+$/, "")
+}
+
+function stripLeadingDotSlash(value: string): string {
+  let next = value
+  while (next.startsWith("./")) next = next.slice(2)
+  return next
+}

--- a/packages/desktop-bridge/src/index.ts
+++ b/packages/desktop-bridge/src/index.ts
@@ -68,6 +68,7 @@ export interface DesktopBridge {
       images?: AgentImageContent[]
       model?: { providerID: string; modelID: string } | null
       thinkingLevel?: AgentThinkingLevel
+      streamingBehavior?: "steer" | "followUp"
     }): Promise<void>
     abort(args: { sessionID: string }): Promise<void>
     renameSession(args: { sessionID: string; name: string; directory?: string }): Promise<void>
@@ -189,6 +190,7 @@ export type {
   AgentModel,
   AgentProvider,
   AgentProviderData,
+  AgentPromptQueueState,
   AgentQuestionInfo,
   AgentQuestionOption,
   AgentQuestionRequest,
@@ -214,6 +216,28 @@ export type {
 } from "./types.js"
 
 export type { SkillPreview } from "./types.js"
+
+export {
+  GENERATED_SCREEN_CANONICAL_DIR,
+  GENERATED_SCREEN_EXTENSION,
+  GENERATED_SCREEN_LEGACY_FALLBACK_DIRS,
+  classifyGeneratedScreenFile,
+  getCanonicalGeneratedScreenDirectory,
+  getCanonicalGeneratedScreenPath,
+  getGeneratedScreenDirectories,
+  getGeneratedScreenFallbackKey,
+  getGeneratedScreenSearchDirectories,
+  isGeneratedScreenFile,
+  renderGeneratedScreenOutputRules,
+  renderGeneratedScreenSystemPromptRules,
+  renderHtmlScreenContract,
+} from "./generated-screen-policy.ts"
+
+export type {
+  GeneratedScreenDirectory,
+  GeneratedScreenDirectoryKind,
+  GeneratedScreenFileMatch,
+} from "./generated-screen-policy.ts"
 
 declare global {
   interface Window {

--- a/packages/desktop-bridge/src/types.ts
+++ b/packages/desktop-bridge/src/types.ts
@@ -140,6 +140,12 @@ export interface AgentImageContent {
   mimeType: string
 }
 
+export interface AgentPromptQueueState {
+  sessionID: string
+  steering: string[]
+  followUp: string[]
+}
+
 export interface AgentMessagePart {
   id: string
   messageID: string

--- a/packages/desktop-bridge/tsconfig.json
+++ b/packages/desktop-bridge/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
     "noEmit": true,
     "isolatedModules": true,
-    "allowImportingTsExtensions": false,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true
   },
   "include": ["src"]

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -212,10 +212,10 @@ function Sidebar({
       <div
         data-slot="sidebar-gap"
         className={cn(
-          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-150 ease-out",
           "group-data-[collapsible=offcanvas]:w-0",
           "group-data-[side=right]:rotate-180",
-          variant === "floating" || variant === "inset"
+          variant === "floating"
             ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
             : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
         )}
@@ -223,14 +223,14 @@ function Sidebar({
       <div
         data-slot="sidebar-container"
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-150 ease-out md:flex",
           side === "left"
             ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
             : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
-          // Adjust the padding for floating and inset variants.
-          variant === "floating" || variant === "inset"
+          // Adjust the padding for floating variants.
+          variant === "floating"
             ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
-            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
           className,
         )}
         {...props}
@@ -238,7 +238,7 @@ function Sidebar({
         <div
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
-          className="bg-sidebar group-data-[variant=floating]:border-sidebar-border group-data-[variant=inset]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=inset]:rounded-xl group-data-[variant=floating]:border group-data-[variant=inset]:border group-data-[variant=floating]:shadow-sm group-data-[variant=inset]:shadow-sm"
+          className="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
         >
           {children}
         </div>
@@ -300,7 +300,7 @@ function SidebarInset({ className, children, ...props }: React.ComponentProps<"m
       data-slot="sidebar-inset"
       className={cn(
         "bg-background relative flex w-full flex-1 flex-col",
-        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        "md:peer-data-[variant=inset]:rounded-tl-xl md:peer-data-[variant=inset]:shadow-sm",
         className,
       )}
       {...props}
@@ -395,7 +395,7 @@ function SidebarGroupLabel({
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        "text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-150 ease-out focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className,
       )}
@@ -461,7 +461,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] duration-150 ease-out hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary

Centralizes Dilag generated-screen output rules, adds follow-up prompt queue handling, and streamlines the desktop studio navigation/composer flow.

## Changes

- Commit 1: centralize generated screen policy, skill-pack rendering, canonical `.designs/` loading with legacy fallback, and docs/tests.
- Commit 2: extract prompt delivery, support Pi follow-up queue events, and expose queued follow-ups in chat.
- Commit 3: streamline the new-design/studio navigation flow and sidebar/titlebar layout.

## Testing

- `bun run --cwd apps/desktop test --run`

## Notes

- Removed local `.designs/` scratch files before committing.