### PR TITLE
Fix message fork sessions

### DIFF
--- a/apps/desktop/electron/ipc/host.ts
+++ b/apps/desktop/electron/ipc/host.ts
@@ -12,6 +12,7 @@ import {
   clearAgentPromptQueue,
   createAgentSessionForDirectory,
   deleteAgentSession,
+  forkAgentSession,
   getAgentMessages,
   getAgentProviderData,
   getAgentRuntimeInfo,
@@ -147,6 +148,10 @@ export function registerHostHandlers(getWindow: () => BrowserWindow | null) {
   )
   ipcMain.handle(CHANNELS.agent.getTree, (_event, args: { sessionID: string }) =>
     getAgentTree(args),
+  )
+  ipcMain.handle(
+    CHANNELS.agent.forkSession,
+    (_event, args: { sessionID: string; targetId: string }) => forkAgentSession(args),
   )
   ipcMain.handle(
     CHANNELS.agent.navigateTree,

--- a/apps/desktop/electron/ipc/pi.ts
+++ b/apps/desktop/electron/ipc/pi.ts
@@ -450,6 +450,27 @@ export function getAgentTree(args: { sessionID: string }): BridgeAgentTreeNode[]
     .map((node) => mapTreeNode(node as PiSessionTreeNode))
 }
 
+export async function forkAgentSession(args: {
+  sessionID: string
+  targetId: string
+}): Promise<AgentSessionInfo> {
+  const sourceRuntime = getRuntimeSession(args.sessionID)
+  const targetId = resolveTreeTargetId(sourceRuntime, args.targetId)
+  const sessionFile = sourceRuntime.session.sessionManager.createBranchedSession(targetId)
+  if (!sessionFile) throw new Error("Unable to fork unsaved session.")
+
+  const pi = await loadPi()
+  const sessionManager = pi.SessionManager.open(
+    sessionFile,
+    getPiSessionDir(sourceRuntime.cwd),
+    sourceRuntime.cwd,
+  )
+  const { session } = await createPiSession(sourceRuntime.cwd, sessionManager)
+  const runtime = bindRuntimeSession(session, sourceRuntime.cwd)
+  sessions.set(runtime.id, runtime)
+  return toAgentSessionInfo(runtime)
+}
+
 export async function navigateAgentTree(args: {
   sessionID: string
   targetId: string

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -58,6 +58,7 @@ const bridge: DesktopBridge = {
     replyQuestion: (args) => ipcRenderer.invoke(CHANNELS.agent.replyQuestion, args),
     rejectQuestion: (args) => ipcRenderer.invoke(CHANNELS.agent.rejectQuestion, args),
     getTree: (args) => ipcRenderer.invoke(CHANNELS.agent.getTree, args),
+    forkSession: (args) => ipcRenderer.invoke(CHANNELS.agent.forkSession, args),
     navigateTree: (args) => ipcRenderer.invoke(CHANNELS.agent.navigateTree, args),
     onEvent: (listener) => subscribe(CHANNELS.agent.event, listener),
   },

--- a/apps/desktop/electron/shared/channels.ts
+++ b/apps/desktop/electron/shared/channels.ts
@@ -30,6 +30,7 @@ export const CHANNELS = {
     replyQuestion: "agent:reply-question",
     rejectQuestion: "agent:reject-question",
     getTree: "agent:get-tree",
+    forkSession: "agent:fork-session",
     navigateTree: "agent:navigate-tree",
     event: "agent:event",
   },

--- a/apps/desktop/src/components/blocks/layout/app-sidebar.tsx
+++ b/apps/desktop/src/components/blocks/layout/app-sidebar.tsx
@@ -643,7 +643,7 @@ function ProjectItem({
   onRemove: () => void
   onStartNewChat: () => void
   onRenameSession: (sessionId: string, name: string) => void
-  onDeleteSession: (sessionId: string) => void
+  onDeleteSession: (sessionId: string) => void | Promise<void>
 }) {
   const navigate = useNavigate()
   const location = useLocation()
@@ -780,7 +780,17 @@ function ProjectItem({
                     </DropdownMenuItem>
                     <DropdownMenuSeparator />
                     <DropdownMenuItem
-                      onSelect={() => onDeleteSession(session.id)}
+                      onSelect={() => {
+                        void (async () => {
+                          await onDeleteSession(session.id)
+                          if (isSessionActive) {
+                            navigate({
+                              to: "/project/$projectId",
+                              params: { projectId: project.id },
+                            })
+                          }
+                        })()
+                      }}
                       className="text-destructive focus:text-destructive"
                     >
                       <TrashBinMinimalistic size={16} className="mr-2" />

--- a/apps/desktop/src/hooks/use-session-data.ts
+++ b/apps/desktop/src/hooks/use-session-data.ts
@@ -16,7 +16,10 @@ export const sessionKeys = {
 function displayNameFromAgentSession(name: string | undefined, firstMessage: string | undefined) {
   const source = name || firstMessage || "New chat"
   const skillMatch = source.match(/<\/skill>\s*([\s\S]*)$/)
-  const cleaned = (skillMatch?.[1] || source).trim()
+  const withoutSkillPrefix = skillMatch?.[1] || source
+  const cleaned = withoutSkillPrefix
+    .replace(/<dilag_context\b[^>]*>[\s\S]*?<\/dilag_context>/g, "")
+    .trim()
   return cleaned || "New chat"
 }
 

--- a/apps/desktop/src/hooks/use-sessions.test.ts
+++ b/apps/desktop/src/hooks/use-sessions.test.ts
@@ -58,6 +58,7 @@ import { useCurrentSession } from "@/hooks/use-session-data"
 const mockPrompt = vi.mocked(window.desktopBridge!.agent.prompt)
 const mockCreateAgentSession = vi.mocked(window.desktopBridge!.agent.createSession)
 const mockAbort = vi.mocked(window.desktopBridge!.agent.abort)
+const mockForkAgentSession = vi.mocked(window.desktopBridge!.agent.forkSession)
 const mockNavigateTree = vi.mocked(window.desktopBridge!.agent.navigateTree)
 const mockGetSession = vi.mocked(window.desktopBridge!.agent.getSession)
 const mockGetMessages = vi.mocked(window.desktopBridge!.agent.getMessages)
@@ -86,6 +87,11 @@ describe("use-sessions", () => {
       title: "New chat",
     })
     mockAbort.mockResolvedValue(undefined)
+    mockForkAgentSession.mockResolvedValue({
+      id: "session-fork",
+      cwd: "/mock/cwd/1",
+      title: "Fork",
+    })
     mockNavigateTree.mockResolvedValue({ cancelled: false })
     mockGetSession.mockResolvedValue({
       id: "session-1",
@@ -352,8 +358,8 @@ describe("use-sessions", () => {
     })
   })
 
-  describe("tree navigation", () => {
-    it("uses Pi tree navigation for forking from a message", async () => {
+  describe("forkSession", () => {
+    it("creates a new Pi session forked from a message", async () => {
       const { result } = renderHook(() => useSessions(), { wrapper: createWrapper() })
       let forkedSessionId: string | null = null
 
@@ -361,12 +367,18 @@ describe("use-sessions", () => {
         forkedSessionId = await result.current.forkSession("msg-1")
       })
 
-      expect(mockNavigateTree).toHaveBeenCalledWith({
+      expect(mockForkAgentSession).toHaveBeenCalledWith({
         sessionID: "session-1",
         targetId: "msg-1",
-        summarize: false,
       })
-      expect(forkedSessionId).toBe("session-1")
+      expect(window.desktopBridge!.sessions.saveMeta).toHaveBeenCalledWith({
+        session: expect.objectContaining({
+          id: "session-fork",
+          cwd: "/mock/cwd/1",
+          parentID: "session-1",
+        }),
+      })
+      expect(forkedSessionId).toBe("session-fork")
     })
   })
 })

--- a/apps/desktop/src/hooks/use-sessions.ts
+++ b/apps/desktop/src/hooks/use-sessions.ts
@@ -451,28 +451,53 @@ export function useSessions() {
     }
   }, [currentSessionId, currentSession, setSessionStatus])
 
-  // Navigate the Pi session tree to a previous message. Pi keeps this in the same
-  // session file instead of creating a separate revert state.
+  // Fork a Pi session at a previous message into a separate session file.
   const forkSession = useCallback(
     async (messageId: string): Promise<string | null> => {
       if (!currentSessionId || !currentSession) return null
 
       try {
         setError(null)
-        await bridge.agent.navigateTree({
+        const response = await bridge.agent.forkSession({
           sessionID: currentSessionId,
           targetId: messageId,
-          summarize: false,
         })
-        await loadSessionMessages(currentSessionId, currentSession.cwd)
-        return currentSessionId
+        const newSessionId = response.id
+        const now = new Date().toISOString()
+        const sessionMeta: SessionMeta = {
+          id: newSessionId,
+          name: `Fork of ${currentSession.name}`,
+          created_at: now,
+          updated_at: now,
+          cwd: currentSession.cwd,
+          parentID: currentSessionId,
+          platform: currentSession.platform,
+          projectId: currentSession.projectId,
+          favorite: currentSession.favorite,
+        }
+        await bridge.sessions.saveMeta({ session: sessionMeta })
+
+        queryClient.setQueryData<SessionMeta[]>(sessionKeys.list(), (old) =>
+          old ? [...old, sessionMeta] : [sessionMeta],
+        )
+        queryClient.invalidateQueries({ queryKey: sessionKeys.list() })
+        setCurrentSessionId(newSessionId)
+        await loadSessionMessages(newSessionId, currentSession.cwd)
+        return newSessionId
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to navigate session tree")
-        console.error("Failed to navigate session tree:", err)
+        setError(err instanceof Error ? err.message : "Failed to fork session")
+        console.error("Failed to fork session:", err)
         return null
       }
     },
-    [currentSessionId, currentSession, loadSessionMessages, setError],
+    [
+      currentSessionId,
+      currentSession,
+      queryClient,
+      setCurrentSessionId,
+      loadSessionMessages,
+      setError,
+    ],
   )
 
   // Fork session with designs only - creates a new session and copies screen designs (no chat history)

--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -42,6 +42,7 @@ const desktopBridgeMock: DesktopBridge = {
     replyQuestion: vi.fn(),
     rejectQuestion: vi.fn(),
     getTree: vi.fn(),
+    forkSession: vi.fn(),
     navigateTree: vi.fn(),
     onEvent: vi.fn(() => noopUnsubscribe),
   },

--- a/packages/desktop-bridge/src/index.ts
+++ b/packages/desktop-bridge/src/index.ts
@@ -79,6 +79,7 @@ export interface DesktopBridge {
     replyQuestion(args: { requestID: string; answers: string[][] }): Promise<void>
     rejectQuestion(args: { requestID: string }): Promise<void>
     getTree(args: { sessionID: string }): Promise<AgentTreeNode[]>
+    forkSession(args: { sessionID: string; targetId: string }): Promise<AgentSessionInfo>
     navigateTree(args: {
       sessionID: string
       targetId: string


### PR DESCRIPTION
## Summary

Create a separate desktop session when forking from a specific chat message, preserving chat history only up to that selected point.

## Changes

- Add a desktop bridge/IPC method for Pi session forking
- Use Pi branched session creation instead of in-place tree navigation
- Save fork metadata so the new session appears under the same project in the sidebar
- Update session hook tests and bridge test mocks

## Testing

- `bun run fmt`
- `bun run lint`